### PR TITLE
Automatically restore older basebackup on repeated failure

### DIFF
--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -21,7 +21,7 @@ class BasebackupOperation:
     callback is executed on another thread so that the main thread can manage backup
     state information while the data is being persisted."""
 
-    current_file_re = re.compile(r" Compressing, encrypting and streaming (.*?)( to <STDOUT>)?$")
+    current_file_re = re.compile(r" Compressing, encrypting and streaming (.*?)( to <STDOUT>)?( up to position \d+)?$")
     binlog_info_re = re.compile(
         r"MySQL binlog position: filename '(?P<fn>.+)', position '(?P<pos>\d+)'(, GTID of the last change '(?P<gtid>.+)')?$"
     )

--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -395,12 +395,14 @@ def sort_and_filter_binlogs(*, binlogs, last_index, log, promotions):
                 server_id, ranges
             )
         else:
-            if index != last_index + 1:
+            adjusted_index = binlog.get("adjusted_remote_index", index)
+            if adjusted_index != last_index + 1:
                 raise Exception(
-                    "Binlog sequence has a gap, expected {} after {}, found {}".format(last_index + 1, last_index, index)
+                    f"Binlog sequence has a gap, expected {last_index + 1} after {last_index}, found {adjusted_index}: "
+                    f"{binlog} / {binlogs}"
                 )
             valid_binlogs.append(binlog)
-            last_index = index
+            last_index = adjusted_index
 
     return valid_binlogs
 

--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -71,6 +71,7 @@ async def test_backup_list(master_controller, web_client):
 
     async def has_backup():
         response = await get_and_verify_json_body(web_client, "/backup")
+        assert response["backups"]
         assert len(response["backups"]) == 1
         backup = response["backups"][0]
         expected = {"basebackup_info", "closed_at", "completed_at", "recovery_site", "resumable", "site", "stream_id"}


### PR DESCRIPTION
It is possible for basebackups to be corrupt in some rare cases.
Depending on the issue it could possibly be resolved manually but
automatic restoration would fail. The binary logs in such cases should
be usable and restoring older basebackup and all binary logs from the
older backup and the new backup whose basebackup was unusable should
yield the same end result.