### PR TITLE
Fix file transfer handling in backup stream and restore coordinator

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -571,6 +571,7 @@ class RestoreCoordinator(threading.Thread):
     def _basebackup_data_provider(self, target_stream):
         name = self._build_full_name("basebackup.xbstream")
         compressed_size = self.state["basebackup_info"].get("compressed_size")
+        file_storage = get_transfer(self.file_storage_config)
 
         last_time = [time.monotonic()]
         last_value = [0]
@@ -592,7 +593,7 @@ class RestoreCoordinator(threading.Thread):
                     stats=self.stats,
                 )
 
-        self.file_storage.get_contents_to_fileobj(name, target_stream, progress_callback=download_progress)
+        file_storage.get_contents_to_fileobj(name, target_stream, progress_callback=download_progress)
 
     def _get_iteration_sleep(self):
         if self.phase in self.POLL_PHASES:

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -31,11 +31,10 @@ def _restore_coordinator_sequence(session_tmpdir, mysql_master, mysql_empty, *, 
 
     private_key_pem, public_key_pem = generate_rsa_key_pair()
     backup_target_location = session_tmpdir().strpath
-    file_storage = LocalTransfer(backup_target_location)
     state_file_name = os.path.join(session_tmpdir().strpath, "backup_stream.json")
     bs1 = BackupStream(
         backup_reason=BackupStream.BackupReason.requested,
-        file_storage=file_storage,
+        file_storage_setup_fn=lambda: LocalTransfer(backup_target_location),
         mode=BackupStream.Mode.active,
         mysql_client_params=mysql_master["connect_options"],
         mysql_config_file_name=mysql_master["config_name"],
@@ -52,7 +51,7 @@ def _restore_coordinator_sequence(session_tmpdir, mysql_master, mysql_empty, *, 
     # backup and binlogs are applied from several different backups
     bs2 = BackupStream(
         backup_reason=BackupStream.BackupReason.requested,
-        file_storage=file_storage,
+        file_storage_setup_fn=lambda: LocalTransfer(backup_target_location),
         mode=BackupStream.Mode.active,
         mysql_client_params=mysql_master["connect_options"],
         mysql_config_file_name=mysql_master["config_name"],


### PR DESCRIPTION
Some file storage implementation are not thread safe. Ensure single file
transfer instance is never used on more than one thread.