### PR TITLE
Allow gap in GTID sequence when patching GTID executed

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -1031,14 +1031,13 @@ class RestoreCoordinator(threading.Thread):
                     continue
 
                 if existing_range["interval_end"] != gtid_range["start"] - 1:
-                    # This is not expected to happen because gtid_executed is updated whenever binlog is
-                    # rotated so all missing values should've been found from the binlog we parsed. It's
-                    # not clear if there could be some corner case where this could happen and we'd still
-                    # want to update the range but for now log an error and don't try to patch gtid_executed
-                    self.log.error(
+                    # This usually shouldn't happen because gtid_executed is updated whenever binlog is
+                    # rotated so all missing values should've been found from the binlog we parsed. There
+                    # seem to be some corner cases where the backup still ends up containing older GTID
+                    # executed value so that there's a gap in the sequence.
+                    self.log.info(
                         "Existing gtid_executed %r does not end just before new range %r", existing_range, gtid_range
                     )
-                    continue
 
                 cursor.execute(
                     ("UPDATE mysql.gtid_executed SET interval_end = %s "


### PR DESCRIPTION
Code assumed that the first binlog we're restoring has all the
transactions since the last persisted update to the gtid_executed table
because the table should be persisted whenever binlog is rotated. It
seems there are some cases where the backed up gtid_executed table has
not been updated as per that assumption. In the cases seen so far all
data was still present and patching GTID executed as usual would've been
the correct action.