### PR TITLE
Reschedule binary log prefetch operations for new restore coordinator

### DIFF
--- a/myhoard/web_server.py
+++ b/myhoard/web_server.py
@@ -27,6 +27,7 @@ class WebServer:
     def __init__(self, *, controller, http_address="127.0.0.1", http_port, stats):
         super().__init__()
         self.app = web.Application()
+        logging.getLogger("aiohttp.access").setLevel(logging.WARNING)
         self.controller = controller
         self.http_address = http_address
         self.http_port = http_port

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -19,16 +19,16 @@ import threading
 import time
 
 
-def build_controller(*, default_backup_site, mysql_config, session_tmpdir):
+def build_controller(*, default_backup_site, mysql_config, session_tmpdir, state_dir=None, temp_dir=None):
     Controller.ITERATION_SLEEP = 0.1
     Controller.BACKUP_REFRESH_INTERVAL = 0.1
     BackupStream.ITERATION_SLEEP = 0.1
     BackupStream.REMOTE_POLL_INTERVAL = 0.1
 
-    state_dir = os.path.abspath(os.path.join(session_tmpdir().strpath, "myhoard_state"))
-    os.makedirs(state_dir)
-    temp_dir = os.path.abspath(os.path.join(session_tmpdir().strpath, "temp"))
-    os.makedirs(temp_dir)
+    state_dir = state_dir or os.path.abspath(os.path.join(session_tmpdir().strpath, "myhoard_state"))
+    os.makedirs(state_dir, exist_ok=True)
+    temp_dir = temp_dir or os.path.abspath(os.path.join(session_tmpdir().strpath, "temp"))
+    os.makedirs(temp_dir, exist_ok=True)
 
     controller = Controller(
         backup_settings={


### PR DESCRIPTION
If the process is restarted or restore coordinator is re-created due to
config change it could end up in a state where it has pending binary
logs that haven't been downloaded but the download operations were not
scheduled so it ended up doing nothing.

Also log all scheduled prefetch operations and successful responses but
suppress access log for web server.