### PR TITLE
Fix logic for passing MySQL server parameters via systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,13 @@ to be started after full database snapshot has been recovered and restarted
 a couple of times with slightly different settings to allow patching GTID
 executed information appropriately.
 
+**systemd_env_update_command**
+
+A command to invoke before ``systemctl`` to configure MySQL server to use the
+desired configuration options. This is typically just the built-in
+``myhoard_mysql_env_update`` command that writes to MySQL systemd environment
+file. Separate command is needed to allow running the update as root user.
+
 **systemd_service**
 
 Name of the MySQL systemd service.

--- a/myhoard.json
+++ b/myhoard.json
@@ -59,6 +59,9 @@
         }
     },
     "systemctl_command": ["sudo", "/usr/bin/systemctl"],
+    "systemd_env_update_command": [
+        "sudo", "/usr/bin/myhoard_mysql_env_update", "--", "/etc/systemd/system/mysqld.environment", "MYSQLD_OPTS"
+    ],
     "systemd_service": "mysql-server",
     "temporary_directory": "/var/tmp/sample_temp_dir"
 }

--- a/myhoard/update_mysql_environment.py
+++ b/myhoard/update_mysql_environment.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
+import argparse
+import logging
+import sys
+
+
+class EnvironmentUpdater:
+    """Updates given environment variable in given systemd environment variable file.
+    Implemented as separate command to allow executing as root via sudo"""
+
+    def __init__(self, args):
+        self.args = args
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def update(self):
+        try:
+            with open(self.args.environment_file, "r") as f:
+                contents = [
+                    line.rstrip("\n") for line in f.readlines() if line.strip() and not line.startswith(self.args.key)
+                ]
+        except FileNotFoundError:
+            contents = []
+
+        if self.args.value:
+            contents.append(f"{self.args.key}={self.args.value}")
+        with open(self.args.environment_file, "w+") as f:
+            f.write("\n".join(contents) + "\n")
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="Aiven MySQL environment updater")
+    parser.add_argument("environment_file", metavar="FILE", help="Environment file")
+    parser.add_argument("key", help="Environment variable name")
+    parser.add_argument("value", help="Environment variable value")
+    args = parser.parse_args()
+    EnvironmentUpdater(args).update()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     entry_points={
         "console_scripts": [
             "myhoard = myhoard.myhoard:main",
+            "myhoard_mysql_env_update = myhoard.update_mysql_environment:main",
         ],
     },
     author="Rauli Ikonen",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -330,6 +330,9 @@ def fixture_myhoard_config(default_backup_site, mysql_master, session_tmpdir):
             },
         },
         "systemctl_command": ["sudo", "/usr/bin/systemctl"],
+        "systemd_env_update_command": [
+            "sudo", "/usr/bin/myhoard_mysql_env_update", "--", "/etc/systemd/system/mysqld.environment", "MYSQLD_OPTS"
+        ],
         "systemd_service": None,
         "temporary_directory": temp_dir
     }


### PR DESCRIPTION
Old logic relied on invalid assumption about environment variables
getting passed from systemctl to ExecStart definition. The variables
need to be in .environment file instead for the logic to work. Since
the .environment file is typically only writable by root perform the
update via separate command to allow doing it with sudo.