### PR TITLE
tests: Always commit and flush all changes when stopping DataGenerator

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -219,11 +219,13 @@ class DataGenerator(threading.Thread):
                         self.indirect_data_generate(cursor2)
                     time.sleep(self.basic_wait)
 
+                self.commit_pending(cursor1)
+
                 for table_name in self.temp_tables:
                     cursor2.execute(f"INSERT INTO db1.t1 (id, data) SELECT id, data FROM {table_name}")
                     cursor2.execute(f"DROP TEMPORARY TABLE {table_name}")
                     cursor2.execute("COMMIT")
-                    cursor1.execute("FLUSH BINARY LOGS")
+                cursor1.execute("FLUSH BINARY LOGS")
 
     def stop(self):
         self.is_running = False


### PR DESCRIPTION
Potentially fixes transiently failing test_restore_coordinator test in
which DataGenerator sometimes reports there should be more rows in the
target database than there actually are, which could be explained by
some rows not being flushed so they didn't get synchronized to the
target service.