### PR TITLE
tests: Always commit and flush all changes when stopping DataGenerator

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -222,6 +222,7 @@ class DataGenerator(threading.Thread):
                 self.commit_pending(cursor1)
 
                 for table_name in self.temp_tables:
+                    print("Inserting rows from temp table", table_name)
                     cursor2.execute(f"INSERT INTO db1.t1 (id, data) SELECT id, data FROM {table_name}")
                     cursor2.execute(f"DROP TEMPORARY TABLE {table_name}")
                     cursor2.execute("COMMIT")
@@ -253,6 +254,7 @@ class DataGenerator(threading.Thread):
 
     def indirect_data_generate(self, cursor):
         table_name = f"db1.temp_t{self.temp_table_index}"
+        print("Creating temp table", table_name, "start identifier", self.row_count + self.index_offset + 1)
         self.temp_table_index += 1
         cursor.execute(f"CREATE TEMPORARY TABLE {table_name} (id INTEGER, data TEXT)")
         self.temp_tables.append(table_name)
@@ -263,6 +265,7 @@ class DataGenerator(threading.Thread):
             index = random.randrange(0, len(self.temp_tables))
             table_name = self.temp_tables[index]
             self.temp_tables.pop(index)
+            print("Inserting rows from temp table", table_name)
             cursor.execute(f"INSERT INTO db1.t1 (id, data) SELECT id, data FROM {table_name}")
             cursor.execute(f"DROP TEMPORARY TABLE {table_name}")
             cursor.execute("COMMIT")

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -219,11 +219,13 @@ class DataGenerator(threading.Thread):
                         self.indirect_data_generate(cursor2)
                     time.sleep(self.basic_wait)
 
+                self.commit_pending(cursor1)
+
                 for table_name in self.temp_tables:
                     cursor2.execute(f"INSERT INTO db1.t1 (id, data) SELECT id, data FROM {table_name}")
                     cursor2.execute(f"DROP TEMPORARY TABLE {table_name}")
                     cursor2.execute("COMMIT")
-                    cursor1.execute("FLUSH BINARY LOGS")
+                cursor1.execute("FLUSH BINARY LOGS")
 
     def stop(self):
         self.is_running = False

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -202,6 +202,9 @@ def _restore_coordinator_sequence(session_tmpdir, mysql_master, mysql_empty, *, 
         cursor.execute("SHOW MASTER STATUS")
         original_master_status = cursor.fetchone()
         print("Original master status", original_master_status)
+        cursor.execute("SELECT COUNT(*) AS count FROM db1.t1")
+        original_count = cursor.fetchone()["count"]
+        print("Number of rows in original master", original_count)
 
     restored_connect_options = {
         "host": "127.0.0.1",


### PR DESCRIPTION
The flushing change doesn't seem to always fix the test but the failure has been harder to reproduce with that so it may help. Also adds more logging.