### PR TITLE
daemon: Fix handling of simultaneous reload requests

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -896,7 +896,7 @@ class BackupStream(threading.Thread):
                 else:
                     self.log.info(
                         "Local binlog %r contains no GTID ranges and we haven't uploaded any binlogs with GTIDs since "
-                        "promotion. Cannot determine whether the file is needed or not -> skipping"
+                        "promotion. Cannot determine whether the file is needed or not -> skipping", binlog
                     )
 
                 if skip:


### PR DESCRIPTION
If MyHoard got SIGHUP while it was still processing the earlier one it
could end up trying to create new WebServer when previous one was still
starting up, causing the WebServer initialization to fail. This resulted
in old WebServer remaining active with reference to old controller. That
WebServer instance returned obsolete data for backups and was unable to
serve requests like service promotion, causing the daemon to appear to
be functioning normally yet possibly failing at a critical time (when
promotion needed to be done).