### PR TITLE
Handle gtid_executed truncation correctly for multiple servers

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -203,6 +203,9 @@ def test_parse_gtid_executed_and_truncate_gtid_executed():
     myhoard_util.truncate_gtid_executed(gtid_executed, "uuid1:9")
     assert gtid_executed == {"uuid1": [[1, 6], [9, 9]], "uuid2": [[1, 30]]}
     gtid_executed = myhoard_util.parse_gtid_range_string(gtid_executed_str)
+    myhoard_util.truncate_gtid_executed(gtid_executed, "uuid1:9, uuid2:7")
+    assert gtid_executed == {"uuid1": [[1, 6], [9, 9]], "uuid2": [[1, 7]]}
+    gtid_executed = myhoard_util.parse_gtid_range_string(gtid_executed_str)
     myhoard_util.truncate_gtid_executed(gtid_executed, "uuid1:8")
     assert gtid_executed == {"uuid1": [[1, 6]], "uuid2": [[1, 30]]}
     myhoard_util.truncate_gtid_executed(gtid_executed, "uuid2:1")


### PR DESCRIPTION
In some cases it is possible that the active binary log contains
transactions from multiple different servers when a new backup is being
created. In such cases the logic that tried to ensure that the
transactions that are reported to be available in the basebackup do not
contain any transactions that have happened after the basebackup was
created didn't work correctly as it assumed the binary log only had
transactions from single server and didn't parse the string correctly.