### PR TITLE
controller: Remove some unnecessary logging.

### DIFF
--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -773,8 +773,6 @@ def test_collect_binlogs_to_purge():
     )
     assert not binlogs_to_purge
     assert only_binlogs_without_gtids is True
-    log.info.assert_any_call("Binlog %s has no GTIDs, purging is maybe safe", 1)
-    log.info.assert_any_call("Binlog %s has no GTIDs, purging is maybe safe", 2)
 
     binlogs.append({
         "local_index": 3,
@@ -796,6 +794,4 @@ def test_collect_binlogs_to_purge():
     )
     assert binlogs_to_purge == binlogs
     assert only_binlogs_without_gtids is False
-    log.info.assert_any_call("Binlog %s has no GTIDs, purging is maybe safe", 1)
-    log.info.assert_any_call("Binlog %s has no GTIDs, purging is maybe safe", 2)
     log.info.assert_any_call("Binlog %s has been replicated to all servers, purging", 3)


### PR DESCRIPTION
The binlog purge and delete related logging seems to produce a
significant percentage of the total amount of logs, but it is not very
useful information.