### PR TITLE
controller: Skip unnecessary backup and stream refresh

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1364,6 +1364,9 @@ class Controller(threading.Thread):
                     "Not all streams finished marking themselves closed in %.1f seconds", max_completion_wait
                 )
 
+        if not expected_completed and not expected_closed:
+            return
+
         self.state_manager.update_state(backups_fetched_at=0)
         self._refresh_backups_list_and_streams()
 


### PR DESCRIPTION
The backup and stream list is only supposed to be updated if some stream
was marked as completed or closed. Missing return caused them to be
refreshed on every iteration, causing fair amount of useless extra
processing.