### PR TITLE
backup stream: Explicitly copy binlogs input list

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -149,7 +149,7 @@ class BackupStream(threading.Thread):
             "mode": mode,
             "next_index": 0,
             "normalized_backup_time": normalized_backup_time,
-            "pending_binlogs": binlogs or [],
+            "pending_binlogs": list(binlogs) if binlogs else [],
             "prepare_details": {},
             # Set of GTIDs that have been stored persistently to file storage.
             "remote_gtid_executed": {},


### PR DESCRIPTION
The binlog list refers to list of all local binary logs from the
BinlogScanner class. That list must never be modified by anything else
than BinlogScanner itself to avoid unexpected side effects yet
`_upload_binlogs` used to pop items from the list. This caused
controller to fail to delete any binary logs that were not uploaded
to new backup stream until the app was restarted and restored back
to sane state.