### PR TITLE
Keep track of latest completed binlog when BackupStream was created

### DIFF
--- a/myhoard/append_only_state_manager.py
+++ b/myhoard/append_only_state_manager.py
@@ -55,7 +55,7 @@ class AppendOnlyStateManager:
                     header = f.read(self.HEADER_BYTES).decode("utf-8")
                     if not header:
                         break
-                    elif len(header) < self.HEADER_BYTES:
+                    if len(header) < self.HEADER_BYTES:
                         raise EOFError(
                             f"Unexpected end of file at {pos}. Expected {self.HEADER_BYTES} bytes, got only {len(header)}"
                         )

--- a/myhoard/binlog_scanner.py
+++ b/myhoard/binlog_scanner.py
@@ -38,6 +38,10 @@ class BinlogScanner:
         self.stats = stats
         self.server_id = server_id
 
+    @property
+    def latest_complete_binlog_index(self):
+        return self.state["next_index"] - 1
+
     def scan_new(self, added_callback):
         """Scan for any added binlogs. Passes any found binlogs to the given callback function
         before updating internal state."""

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1187,6 +1187,7 @@ class Controller(threading.Thread):
             compression=backup_site.get("compression"),
             file_storage_setup_fn=lambda: get_transfer(backup_site["object_storage"]),
             file_uploaded_callback=self._binlog_uploaded,
+            latest_complete_binlog_index=self.binlog_scanner.latest_complete_binlog_index(),
             mode=BackupStream.Mode.active,
             mysql_client_params=self.mysql_client_params,
             mysql_config_file_name=self.mysql_config_file_name,

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -612,7 +612,7 @@ class Controller(threading.Thread):
             for binlog in stream.iterate_remote_binlogs(reverse=True):
                 if binlog["remote_index"] in already_processed_remote_indexes:
                     break
-                elif not binlog["gtid_ranges"]:
+                if not binlog["gtid_ranges"]:
                     missing_binlogs.insert(0, binlog)
                 else:
                     gtid_str = make_gtid_range_string(binlog["gtid_ranges"])
@@ -1187,7 +1187,7 @@ class Controller(threading.Thread):
             compression=backup_site.get("compression"),
             file_storage_setup_fn=lambda: get_transfer(backup_site["object_storage"]),
             file_uploaded_callback=self._binlog_uploaded,
-            latest_complete_binlog_index=self.binlog_scanner.latest_complete_binlog_index(),
+            latest_complete_binlog_index=self.binlog_scanner.latest_complete_binlog_index,
             mode=BackupStream.Mode.active,
             mysql_client_params=self.mysql_client_params,
             mysql_config_file_name=self.mysql_config_file_name,
@@ -1224,8 +1224,7 @@ class Controller(threading.Thread):
         for backup in backups:
             if backup["stream_id"] == current_stream_id:
                 break
-            else:
-                earlier_backup = backup
+            earlier_backup = backup
         else:
             raise Exception(f"Stream {current_stream_id} being restored not found in completed backups: {backups}")
 

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -663,7 +663,7 @@ class RestoreCoordinator(threading.Thread):
                         )
                         target_time_reached_by_server.add(binlog["server_id"])
                         continue
-                    elif binlog["gtid_ranges"][0]["end_ts"] >= self.target_time:
+                    if binlog["gtid_ranges"][0]["end_ts"] >= self.target_time:
                         # Log and mark target time reached but include binlog and continue processing results. We may
                         # get binlogs from multiple servers in some race conditions and we don't yet know if this binlog
                         # was from a server that was actually valid at that point in time and some other server may have
@@ -1061,12 +1061,11 @@ class RestoreCoordinator(threading.Thread):
                             " VALUES (%s, %s, %s)"
                         ), (gtid_range["server_uuid"], gtid_range["start"], gtid_range["end"]))
                         cursor.execute("COMMIT")
-                        continue
                     else:
                         # This is not expected to happen. We cannot ensure gtid_executed is in sane state if it
                         # happens but applying old binlog is not dependent on this so allow continuing regardless
                         self.log.error("Could not find existing gtid_executed info for range %r", gtid_range)
-                        continue
+                    continue
 
                 if existing_range["interval_end"] == gtid_range["end"]:
                     self.log.info("Existing gtid_executed info already up-to-date, no need to apply %r", gtid_range)

--- a/myhoard/statsd.py
+++ b/myhoard/statsd.py
@@ -58,7 +58,7 @@ class StatsClient:
         if self.sentry_config.get("dsn"):
             try:
                 # Lazy-load raven as this to make importing the file faster
-                import raven
+                import raven  # pylint: disable=import-outside-toplevel
                 self.raven_client = raven.Client(**self.sentry_config)
             except ImportError:
                 self.raven_client = None

--- a/test/test_backup_stream.py
+++ b/test/test_backup_stream.py
@@ -157,3 +157,6 @@ def _run_backup_stream_test(session_tmpdir, mysql_master, backup_stream_class):
     assert not bs_observer.is_binlog_safe_to_delete(new_binlogs[0])
     assert not bs_observer.is_log_backed_up(log_index=new_binlogs[0]["local_index"])
     bs_observer.stop()
+
+    bs.state_manager.update_state(initial_latest_complete_binlog_index=new_binlogs[0]["local_index"])
+    assert bs.is_binlog_safe_to_delete(new_binlogs[0])

--- a/test/test_basebackup_operation.py
+++ b/test/test_basebackup_operation.py
@@ -40,8 +40,7 @@ def test_basic_backup(mysql_master):
             data = stream.read(10 * 1024)
             if not data:
                 break
-            else:
-                bytes_read[0] += len(data)
+            bytes_read[0] += len(data)
 
     encryption_key = os.urandom(24)
     op = BasebackupOperation(

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -259,8 +259,8 @@ def _restore_coordinator_sequence(session_tmpdir, mysql_master, mysql_empty, *, 
             assert rc.state["phase"] != RestoreCoordinator.Phase.failed
             if rc.state["phase"] == RestoreCoordinator.Phase.completed:
                 break
-            else:
-                print("Current restore coordinator phase:", rc.state["phase"])
+
+            print("Current restore coordinator phase:", rc.state["phase"])
             time.sleep(1)
     finally:
         rc.stop()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -31,7 +31,7 @@ def test_read_gtids_from_log():
     ]
     assert events == expected_events
 
-    ranges = [range for range in myhoard_util.build_gtid_ranges(myhoard_util.read_gtids_from_log(fn))]
+    ranges = list(myhoard_util.build_gtid_ranges(myhoard_util.read_gtids_from_log(fn)))
     expected_ranges = [
         {
             "end": 1000010,
@@ -68,7 +68,7 @@ def test_build_gtid_ranges():
         (1003, 2, "b", 5),
         (1004, 2, "b", 6),
     ]
-    ranges = [range for range in myhoard_util.build_gtid_ranges(events)]
+    ranges = list(myhoard_util.build_gtid_ranges(events))
     expected_ranges = [
         {
             "end": 2,


### PR DESCRIPTION
Binary logs that were created before a new backup was started but were
not yet purged could not be purged while basebackup for the new backup
was being created because the new stream didn't have remote references
for those binary logs. Binary logs that exist when new backup is started
cannot be required by the backup stream because basebackup must contain
everything in those so they can be simply ignored by the safety check.