### PR TITLE
Improve promote handling when some binlogs need to be applied

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -143,7 +143,6 @@ class RestoreCoordinator(threading.Thread):
             "basebackup_restore_errors": 0,
             "binlog_name_offset": 0,
             # Corrected binlog position to use instead of the position stored in basebackup info.
-            # For old backups the value in basebackup info might be incorrect.
             "binlog_position": None,
             "binlog_stream_offset": 0,
             "binlogs_restored": 0,

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -100,12 +100,14 @@ def restart_mysql(mysql_config, *, with_binlog=True, with_gtids=True):
         mysql_config["proc"] = None
         os.kill(proc.pid, signal.SIGKILL)
         proc.wait(timeout=20.0)
+        print("Stopped mysqld with pid", proc.pid)
     command = mysql_config["startup_command"]
     if not with_binlog:
         command = command + ["--disable-log-bin", "--skip-slave-preserve-commit-order"]
     if not with_gtids:
         command = command + ["--gtid-mode=OFF"]
     mysql_config["proc"] = subprocess.Popen(command)
+    print("Started mysqld with pid", mysql_config["proc"].pid)
     wait_for_port(mysql_config["port"], wait_time=10)
 
 


### PR DESCRIPTION
Make _apply_downloaded_remote_binlogs re-entrant

Previously the function might have gotten executed half way and if it
was called again it failed because it tried performings things like
renaming files that had already been renamed.

Added a test case that demonstrates the functionality actually works.

---

Automatically start SQL thread if not running

There have been some cases where SQL thread has been expected to be
running but it isn't. It's not clear why it has not started. It may
have been related to the the re-entrancy issues with
_apply_downloaded_remote_binlogs but logs don't clearly support that.
Log the expected replication target to make it easier to see what the
application is doing and if the thread isn't running try to start it
automatically.