### PR TITLE
Allow forcing premature server promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ Updates current main mode of MyHoard. Request must be like this:
 
 ```
 {
+  "force": false,
   "mode": "{active|idle|observe|promote|restore}",
   "site": "{site_name}",
   "stream_id": "{backup_id}",
@@ -595,6 +596,25 @@ Updates current main mode of MyHoard. Request must be like this:
   "target_time_approximate_ok": false
 }
 ```
+
+**force**
+
+This value can only be passed when switching mode to active.
+
+When binary log restoration is ongoing setting this true will cause mode to
+be forcibly switched to promote without waiting for all binary logs to get
+applied and the promote phase will skip the step of ensuring all binary logs
+are applied. If mode is already promote and binary logs are being applied in
+that state, the binary logs sync is considered to be immediately complete.
+If the server is not currently applying binary logs passing ``"force": true``
+will cause the operation to fail with error 400.
+
+This parameter is only intended for exceptional situations. For example
+broken binary logs that cannot be applied and it is preferable to promote the
+server in it's current state. Another possible case is binary logs containing
+changes to large tables without primary keys with row format in use and the
+operation being so slow that it will not complete in reasonable amount of time.
+Data loss will incur when using this option!
 
 **mode**
 

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -277,7 +277,7 @@ class BackupStream(threading.Thread):
         return self.state["immediate_scan_required"]
 
     def is_log_backed_up(self, *, log_index):
-        return log_index < self.highest_processed_local_index
+        return log_index <= self.highest_processed_local_index
 
     def is_streaming_binlogs(self):
         with self.lock:

--- a/myhoard/errors.py
+++ b/myhoard/errors.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
+
+
+class BadRequest(Exception):
+    pass


### PR DESCRIPTION
In case binary logs cannot be applied cleanly (they are corrupt or
contain changes that are too slow to apply), it is now possible to
use the POST /status API to forcibly mark restoration as having
completed and switch MyHoard to active mode. This option will always
cause data loss and must only be used when there are no other options
available.