### PR TITLE
controller: Fix race condition in force promotion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ unittest: $(generated)
 
 .PHONY: pylint
 pylint: $(generated)
-	$(PYTHON) -m pylint.lint --rcfile .pylintrc $(ALL_PYTHON_DIRS)
+	$(PYTHON) -m pylint --rcfile .pylintrc $(ALL_PYTHON_DIRS)
 
 .PHONY: yapf
 yapf:

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -282,7 +282,7 @@ class Controller(threading.Thread):
                     if not self.restore_coordinator:
                         raise ValueError("Cannot switch mode, current restoration state is indeterminate")
                     self.restore_coordinator.force_completion()
-                    self.state_manager.update_state(promote_on_restore_completion=True)
+                    self.state_manager.update_state(force_promote=True, promote_on_restore_completion=True)
                     return
             elif force:
                 raise BadRequest("Can only force promotion while waiting for binlogs to be applied")

--- a/test/test_append_only_state_manager.py
+++ b/test/test_append_only_state_manager.py
@@ -21,7 +21,7 @@ def test_basic_operations(session_tmpdir):
         new_file_size = os.stat(state_file_name).st_size
         assert new_file_size > file_size
         file_size = new_file_size
-        aosm.append({f"foo": f"bar{index + 1}"})
+        aosm.append({"foo": f"bar{index + 1}"})
         assert len(entries) == index + 2
 
     for index in range(1000):


### PR DESCRIPTION
If force promotion was requested while restoring binlogs and new
non-forced promotion was requested just when restore coordination
marked restoration as having finished, the force flag was not set
and promotion wasn't marked as having completed immediately.