### PR TITLE
myhoard: On basebackup command failure raise XtraBackupError

### DIFF
--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -12,6 +12,8 @@ from contextlib import suppress
 
 from pghoard.common import increase_pipe_capacity, set_stream_nonblocking
 
+from myhoard.errors import XtraBackupError
+
 
 class BasebackupOperation:
     """Creates a new basebackup. Provides callback for getting progress info, extracts
@@ -197,7 +199,7 @@ class BasebackupOperation:
 
         if exit_code != 0:
             self.log.error("xtrabackup exited with non-zero exit code %s: %r", exit_code, pending_output)
-            raise Exception(f"xtrabackup failed with code {exit_code}")
+            raise XtraBackupError(f"xtrabackup failed with code {exit_code}")
 
         # Reader thread might have encountered an exception after xtrabackup exited if it hadn't
         # yet finished storing data to backup location

--- a/myhoard/errors.py
+++ b/myhoard/errors.py
@@ -3,3 +3,7 @@
 
 class BadRequest(Exception):
     pass
+
+
+class XtraBackupError(Exception):
+    """Raised when the backup operation fails."""


### PR DESCRIPTION
Identity failures of the backup process command as a specific exception type rather then just Exception, then filter them out of the normal unexpected_exception dispatch. This is because they can't raise any possible error which can be dealt with by looking at Sentry, and don't include any useful error data.