### PR TITLE
test: Refactor tests for improved readability

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
+import contextlib
 import enum
 import json
 import logging
@@ -167,6 +168,13 @@ class BackupStream(threading.Thread):
         self.stats = stats
         self.temp_dir = temp_dir
         self.wakeup_event = threading.Event()
+
+    @contextlib.contextmanager
+    def running(self):
+        """Start the BackupStream thread and shut it down when finished"""
+        self.start()
+        yield
+        self.stop()
 
     def activate(self):
         with self.lock:

--- a/myhoard/state_manager.py
+++ b/myhoard/state_manager.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
+import errno
 import json
 import os
 import threading
@@ -13,6 +14,14 @@ class StateManager:
         self.allow_unknown_keys = allow_unknown_keys
         self.lock = lock or threading.RLock()
         self.state = state
+
+        # Check that the state_file directory actually exists before initializing. If it doesn't
+        # then we'll just crash out later when we try to write to it. We'd prefer to crash here,
+        # where we're more likely to find the problem higher up the stack.
+        state_file_dirname = os.path.dirname(state_file)
+        if not os.path.isdir(state_file_dirname):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), state_file_dirname)
+
         self.state_file = state_file
         self.read_state()
 

--- a/test/test_basebackup_restore_operation.py
+++ b/test/test_basebackup_restore_operation.py
@@ -4,8 +4,9 @@ import shutil
 import subprocess
 import tempfile
 
-import myhoard.util as myhoard_util
 import pytest
+
+import myhoard.util as myhoard_util
 from myhoard.basebackup_operation import BasebackupOperation
 from myhoard.basebackup_restore_operation import BasebackupRestoreOperation
 
@@ -15,7 +16,7 @@ pytestmark = [pytest.mark.unittest, pytest.mark.all]
 
 
 def test_basic_restore(mysql_master, mysql_empty):
-    with myhoard_util.mysql_cursor(**mysql_master["connect_options"]) as cursor:
+    with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
         for db_index in range(15):
             cursor.execute(f"CREATE DATABASE test{db_index}")
             cursor.execute(f"CREATE TABLE test{db_index}.foo{db_index} (id integer primary key)")
@@ -35,12 +36,12 @@ def test_basic_restore(mysql_master, mysql_empty):
         backup_op = BasebackupOperation(
             encryption_algorithm="AES256",
             encryption_key=encryption_key,
-            mysql_client_params=mysql_master["connect_options"],
-            mysql_config_file_name=mysql_master["config_name"],
-            mysql_data_directory=mysql_master["config_options"]["datadir"],
+            mysql_client_params=mysql_master.connect_options,
+            mysql_config_file_name=mysql_master.config_name,
+            mysql_data_directory=mysql_master.config_options.datadir,
             stats=build_statsd_client(),
             stream_handler=output_stream_handler,
-            temp_dir=mysql_master["base_dir"],
+            temp_dir=mysql_master.base_dir,
         )
         backup_op.create_backup()
 
@@ -53,23 +54,23 @@ def test_basic_restore(mysql_master, mysql_empty):
         restore_op = BasebackupRestoreOperation(
             encryption_algorithm="AES256",
             encryption_key=encryption_key,
-            mysql_config_file_name=mysql_empty["config_name"],
-            mysql_data_directory=mysql_empty["config_options"]["datadir"],
+            mysql_config_file_name=mysql_empty.config_name,
+            mysql_data_directory=mysql_empty.config_options.datadir,
             stats=build_statsd_client(),
             stream_handler=input_stream_handler,
-            temp_dir=mysql_empty["base_dir"],
+            temp_dir=mysql_empty.base_dir,
         )
         restore_op.restore_backup()
 
         assert restore_op.number_of_files >= backup_op.number_of_files
 
-    mysql_empty["proc"] = subprocess.Popen(mysql_empty["startup_command"])
-    wait_for_port(mysql_empty["port"])
+    mysql_empty.proc = subprocess.Popen(mysql_empty.startup_command)
+    wait_for_port(mysql_empty.port)
 
     with myhoard_util.mysql_cursor(
-        password=mysql_master["password"],
-        port=mysql_empty["port"],
-        user=mysql_master["user"],
+        password=mysql_master.password,
+        port=mysql_empty.port,
+        user=mysql_master.user,
     ) as cursor:
         for db_index in range(15):
             cursor.execute(f"SELECT id FROM test{db_index}.foo{db_index}")

--- a/test/test_binlog_scanner.py
+++ b/test/test_binlog_scanner.py
@@ -2,8 +2,9 @@
 import json
 import os
 
-import myhoard.util as myhoard_util
 import pytest
+
+import myhoard.util as myhoard_util
 from myhoard.binlog_scanner import BinlogScanner
 
 from . import build_statsd_client
@@ -14,8 +15,8 @@ pytestmark = [pytest.mark.unittest, pytest.mark.all]
 def test_read_gtids_from_log(session_tmpdir, mysql_master):
     state_file_name = os.path.join(session_tmpdir().strpath, "scanner_state.json")
     scanner = BinlogScanner(
-        binlog_prefix=mysql_master["config_options"]["binlog_file_prefix"],
-        server_id=mysql_master["server_id"],
+        binlog_prefix=mysql_master.config_options.binlog_file_prefix,
+        server_id=mysql_master.server_id,
         state_file=state_file_name,
         stats=build_statsd_client(),
     )
@@ -29,7 +30,7 @@ def test_read_gtids_from_log(session_tmpdir, mysql_master):
     with open(state_file_name, "r") as f:
         assert json.load(f) == scanner.state
 
-    with myhoard_util.mysql_cursor(**mysql_master["connect_options"]) as cursor:
+    with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
         cursor.execute("CREATE TABLE foo(id INTEGER PRIMARY KEY)")
         cursor.execute("COMMIT")
         cursor.execute("INSERT INTO foo (id) VALUES (1)")
@@ -53,9 +54,9 @@ def test_read_gtids_from_log(session_tmpdir, mysql_master):
     assert range1["server_uuid"] == server_uuid
     assert range1["start"] == int(range_start)
     assert range1["end"] == int(range_end)
-    assert range1["server_id"] == mysql_master["config_options"]["server_id"]
+    assert range1["server_id"] == mysql_master.config_options.server_id
 
-    with myhoard_util.mysql_cursor(**mysql_master["connect_options"]) as cursor:
+    with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
         cursor.execute("CREATE TABLE foo2(id INTEGER PRIMARY KEY)")
         cursor.execute("COMMIT")
         cursor.execute("FLUSH BINARY LOGS")
@@ -80,7 +81,7 @@ def test_read_gtids_from_log(session_tmpdir, mysql_master):
     scanner.scan_removed(None)
     assert scanner.state == scanner_state
 
-    with myhoard_util.mysql_cursor(**mysql_master["connect_options"]) as cursor:
+    with myhoard_util.mysql_cursor(**mysql_master.connect_options) as cursor:
         cursor.execute("FLUSH BINARY LOGS")
 
     scanner.scan_new(None)
@@ -92,8 +93,8 @@ def test_read_gtids_from_log(session_tmpdir, mysql_master):
     assert len(binlog4["gtid_ranges"]) == 0
 
     scanner = BinlogScanner(
-        binlog_prefix=mysql_master["config_options"]["binlog_file_prefix"],
-        server_id=mysql_master["server_id"],
+        binlog_prefix=mysql_master.config_options.binlog_file_prefix,
+        server_id=mysql_master.server_id,
         state_file=state_file_name,
         stats=build_statsd_client(),
     )


### PR DESCRIPTION
Some miscellaneous work from the last 2 PRs - pull the test objects out to be actual objects rather then dictionaries to allow typed passing of test configuration data. Adds the ability to use the BackupStream as a context manager for limiting the duration of the runs. This was critical in diagnosing the cause of test failures, which can otherwise be buried under temporary file cleanup issues.