### PR TITLE
Cleanup slave relay log info from the backup

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1283,6 +1283,7 @@ class Controller(threading.Thread):
                 if not retry:
                     raise ex
                 self.log.error("Failed to flush binary logs due to %s, retrying: %r", due_to, ex)
+        return None
 
     def _rotate_binlog_if_threshold_exceeded(self):
         # If we haven't seen new binlogs in a while, forcibly flush binlogs so that we upload latest


### PR DESCRIPTION
Old replication information from the backup might bring problems. When backup is taken from the slave, which has active replication, and restored to another standby/replica, this relay info might conflict and will end up in breaking restoration process.
    
In some cases, e.g. when rotate event appears in the relay log (coming from master binlog) and mysql has some information about non-existing replication in these tables, it tries to read previous relays logs in order to find last rotate event, but those relay logs do not exist anymore.
   
Unfortunately it's not possible to exclude these tables from the backup using xtrabackup at the moment, would have been a better option.
