### PR TITLE
readme: point CI badge to GitHub Actions instead Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MyHoard [![Build Status](https://travis-ci.org/aiven/myhoard.png?branch=master)](https://travis-ci.org/aiven/myhoard)
+MyHoard [![Build Status](https://github.com/aiven/myhoard/workflows/Build%20MyHoard/badge.svg?branch=master)](https://github.com/aiven/myhoard/actions)
 =====================================================================================================================
 
 MyHoard is a daemon for creating, managing and restoring MySQL backups.


### PR DESCRIPTION
# About this change: What it does, why it matters

Point CI badge to GitHub Actions instead Travis