### PR TITLE
remove stored state for old basebackups [BF-364]

### DIFF
--- a/myhoard/append_only_state_manager.py
+++ b/myhoard/append_only_state_manager.py
@@ -127,3 +127,7 @@ class AppendOnlyStateManager:
         full_data = self._encode_entries(entries)
         with atomic_create_file(self.state_file, binary=True) as f:
             f.write(full_data)
+
+    def delete_state(self):
+        if os.path.exists(self.state_file):
+            os.remove(self.state_file)

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -387,7 +387,7 @@ class BackupStream(threading.Thread):
     def remove(self):
         self.stop()
         file_storage = self.file_storage_setup_fn()
-        self.state_manager.delete_state()
+        self.delete_state()
         try:
             file_storage.delete_tree(f"{self.site}/{self.stream_id}")
         except FileNotFoundError:
@@ -395,6 +395,10 @@ class BackupStream(threading.Thread):
         except Exception as ex:  # pylint: disable=broad-except
             self.log.error("Removing remote backup failed: %r", ex)
             self.stats.unexpected_exception(ex=ex, where="BackupStream.remove")
+
+    def delete_state(self):
+        self.state_manager.delete_state()
+        self.remote_binlog_manager.delete_state()
 
     def remove_binlogs(self, binlogs):
         # If the stream has been closed we don't care about tracking binlogs for it anymore

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1171,6 +1171,10 @@ class Controller(threading.Thread):
         backups = self.get_backup_list(
             self.backup_sites, seen_basebackup_infos=self.seen_basebackup_infos, site_transfers=self.site_transfers
         )
+        new_backups_ids = {backup["stream_id"] for backup in backups}
+        for backup in self.state["backups"]:
+            if backup["stream_id"] not in new_backups_ids:
+                self._build_backup_stream(backup).delete_state()
         self.state_manager.update_state(backups=backups, backups_fetched_at=time.time())
         return backups
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
+markers =
+    all
+    unittest
 filterwarnings =
     ignore:\((1007|1050|1753|1759|1760|3084|3129):pymysql.Warning

--- a/test/test_append_only_state_manager.py
+++ b/test/test_append_only_state_manager.py
@@ -77,3 +77,6 @@ def test_basic_operations(session_tmpdir):
     entries2 = []
     AppendOnlyStateManager(entries=entries2, state_file=state_file_name)
     assert set(entry["foo"] for entry in entries2) == {f"bar{index}" for index in range(1005, 1013)}
+
+    AppendOnlyStateManager(entries=[], state_file=state_file_name).delete_state()
+    assert not os.path.exists(state_file_name)

--- a/test/test_backup_stream.py
+++ b/test/test_backup_stream.py
@@ -160,3 +160,7 @@ def _run_backup_stream_test(session_tmpdir, mysql_master: MySQLConfig, backup_st
 
     bs.state_manager.update_state(initial_latest_complete_binlog_index=new_binlogs[0]["local_index"])
     assert bs.is_binlog_safe_to_delete(new_binlogs[0])
+
+    bs.delete_state()
+    assert not os.path.exists(bs.state_manager.state_file)
+    assert not os.path.exists(bs.remote_binlog_manager.state_file)


### PR DESCRIPTION
Remove old .json and .remote_binlogs files related to basebackups that don't exist anymore.