### PR TITLE
silence or comply with new warning from pylint 2.8.0

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -164,7 +164,7 @@ def restart_mysql(mysql_config, *, with_binlog=True, with_gtids=True):
         command = command + ["--disable-log-bin", "--skip-slave-preserve-commit-order"]
     if not with_gtids:
         command = command + ["--gtid-mode=OFF"]
-    mysql_config.proc = subprocess.Popen(command)
+    mysql_config.proc = subprocess.Popen(command)   # pylint: disable=consider-using-with
     print("Started mysqld with pid", mysql_config.proc.pid)
     wait_for_port(mysql_config.port, wait_time=10)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -168,8 +168,7 @@ FLUSH PRIVILEGES;
             "--init-file",
             init_file,
         ])
-        proc = subprocess.Popen(cmd)
-        proc.wait(timeout=30)
+        subprocess.run(cmd, check=True, timeout=30)
 
     connect_options = {
         "host": "127.0.0.1",
@@ -187,7 +186,7 @@ FLUSH PRIVILEGES;
         shutil.rmtree(config_options.datadir)
         proc = None
     else:
-        proc = subprocess.Popen(cmd)
+        proc = subprocess.Popen(cmd)  # pylint: disable=consider-using-with
         wait_for_port(host="127.0.0.1", port=config_options.port, timeout=30.0)
         # Ensure connecting to the newly started server works and if this is standby also start replication
         with mysql_cursor(**connect_options) as cursor:

--- a/test/test_basebackup_restore_operation.py
+++ b/test/test_basebackup_restore_operation.py
@@ -64,7 +64,7 @@ def test_basic_restore(mysql_master, mysql_empty):
 
         assert restore_op.number_of_files >= backup_op.number_of_files
 
-    mysql_empty.proc = subprocess.Popen(mysql_empty.startup_command)
+    mysql_empty.proc = subprocess.Popen(mysql_empty.startup_command)  # pylint: disable=consider-using-with
     wait_for_port(mysql_empty.port)
 
     with myhoard_util.mysql_cursor(


### PR DESCRIPTION
pylint introduced a consider-using-with warning to detect resource creation
not handled with a context manager.

This adds a context manager where it makes sense and silences the warning
when the code is taking responsibility of the resource by other means.


