### PR TITLE
don't try to remove state of backups from unknown sites

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1173,7 +1173,7 @@ class Controller(threading.Thread):
         )
         new_backups_ids = {backup["stream_id"] for backup in backups}
         for backup in self.state["backups"]:
-            if backup["stream_id"] not in new_backups_ids:
+            if backup["stream_id"] not in new_backups_ids and backup["site"] in self.backup_sites:
                 self._build_backup_stream(backup).delete_state()
         self.state_manager.update_state(backups=backups, backups_fetched_at=time.time())
         return backups


### PR DESCRIPTION
This fixes a crash when trying to remove dangling state when the backup site itself isn't known :
```
Traceback (most recent call last):
   File "/usr/lib/python3.9/site-packages/myhoard/controller.py", line 243, in run
     self._handle_mode_promote()
   File "/usr/lib/python3.9/site-packages/myhoard/controller.py", line 929, in _handle_mode_promote
     self._refresh_backups_list_and_streams()
   File "/usr/lib/python3.9/site-packages/myhoard/controller.py", line 1190, in _refresh_backups_list_and_streams
     if self._refresh_backups_list() is None and self.backup_streams_initialized:
   File "/usr/lib/python3.9/site-packages/myhoard/controller.py", line 1177, in _refresh_backups_list
     self._build_backup_stream(backup).delete_state()
   File "/usr/lib/python3.9/site-packages/myhoard/controller.py", line 552, in _build_backup_stream
     backup_site = self.backup_sites[backup["site"]]
```