### PR TITLE
remove state of backups from unknown sites

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -85,6 +85,7 @@ class BackupStream(threading.Thread):
         mysql_data_directory,
         normalized_backup_time,
         rsa_public_key_pem,
+        remote_binlogs_state_file,
         server_id,
         site,
         state_file,
@@ -115,10 +116,9 @@ class BackupStream(threading.Thread):
         self.mysql_data_directory = mysql_data_directory
         # Keep track of remote binlogs so that we can drop binlogs containing only GTID
         # ranges that have already been backed up from our list of pending binlogs
-        remote_binlog_state_name = state_file.replace(".json", "") + ".remote_binlogs"
         remote_binlogs = []
         self.remote_binlog_manager = AppendOnlyStateManager(
-            entries=remote_binlogs, lock=self.lock, state_file=remote_binlog_state_name
+            entries=remote_binlogs, lock=self.lock, state_file=remote_binlogs_state_file
         )
         self.remote_binlogs = remote_binlogs
         self.known_remote_binlogs = {binlog["remote_index"] for binlog in self.remote_binlogs}

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -34,6 +34,8 @@ def _restore_coordinator_sequence(session_tmpdir, mysql_master, mysql_empty, *, 
     backup_target_location = session_tmpdir().strpath
     state_file_name1 = os.path.join(session_tmpdir().strpath, "backup_stream1.json")
     state_file_name2 = os.path.join(session_tmpdir().strpath, "backup_stream2.json")
+    remote_binlogs_state_file_name1 = os.path.join(session_tmpdir().strpath, "backup_stream1.remote_binlogs")
+    remote_binlogs_state_file_name2 = os.path.join(session_tmpdir().strpath, "backup_stream2.remote_binlogs")
     bs1 = BackupStream(
         backup_reason=BackupStream.BackupReason.requested,
         file_storage_setup_fn=lambda: LocalTransfer(backup_target_location),
@@ -43,6 +45,7 @@ def _restore_coordinator_sequence(session_tmpdir, mysql_master, mysql_empty, *, 
         mysql_data_directory=mysql_master.config_options.datadir,
         normalized_backup_time="2019-02-25T08:20",
         rsa_public_key_pem=public_key_pem,
+        remote_binlogs_state_file=remote_binlogs_state_file_name1,
         server_id=mysql_master.server_id,
         site="default",
         state_file=state_file_name1,
@@ -60,6 +63,7 @@ def _restore_coordinator_sequence(session_tmpdir, mysql_master, mysql_empty, *, 
         mysql_data_directory=mysql_master.config_options.datadir,
         normalized_backup_time="2019-02-26T08:20",
         rsa_public_key_pem=public_key_pem,
+        remote_binlogs_state_file=remote_binlogs_state_file_name2,
         server_id=mysql_master.server_id,
         site="default",
         state_file=state_file_name2,


### PR DESCRIPTION
This remove local state for backups that were removed,
even when the backup_site itself isn't known anymore.

This is made safe by not trying to create a complex BackupStream
object just for the purpose of removing its local state.
