### PR TITLE
controller: Ensure completed streams are recorded before stopping

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -245,6 +245,10 @@ class Controller(threading.Thread):
                     assert False, "Invalid mode {}".format(self.mode)
                 self.wakeup_event.wait(self._get_iteration_sleep())
                 self.wakeup_event.clear()
+                if self.mode == self.Mode.active and not self.is_running:
+                    # Update stream statuses before closing controller in case some of the
+                    # streams has just completed so that list of active backups is refreshed
+                    self._update_stream_completed_and_closed_statuses()
             except Exception as ex:  # pylint: disable=broad-except
                 self.log.exception("Unexpected exception in mode %s", self.mode)
                 self.stats.unexpected_exception(ex=ex, where="Controller.run")


### PR DESCRIPTION
This should prevent the following from happening:

1. First scheduled backup is started
2. Backup time is changed
3. Basebackup from step 1 finishes
4. Daemon main loop stops controller
5. Config is reloaded
6. Daemon main loop starts controller
7. Controller does not load backups from object storage because last load
   happened fairly recently so backup from step 1 is not visible
8. New normalized backup time differs from previous one, as there are no
   backups new backup is created immediately
9. Basebackup from step 8 finishes
10. Completed streams are processed and list of backups is refreshed

With this change step 10 happens at step 4 and no new backup is started
in step 8 because there is already a known backup that is very recent.

# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)


