### PR TITLE
controller: Add missing return statement

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1071,6 +1071,7 @@ class Controller(threading.Thread):
         # This shouldn't happen but better not drop backup that is active
         if any(stream.stream_id == backup["stream_id"] for stream in self.backup_streams):
             self.log.warning("Backup %r to drop is one of active streams, not dropping", backup["stream_id"])
+            return
 
         self._build_backup_stream(backup).remove()
         with self.lock:


### PR DESCRIPTION
Active stream was not supposed to be dropped but there was no return
statement so it was anyway

# About this change: What it does, why it matters

The code looked to be clearly not matching the intent as specified by the comment. I don't know if this branch is in practice ever reached and if this was actually causing any problems, just happened to notice this when reading through the code while looking into a totally unrelated issue.

