### PR TITLE
ci: enable mypy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     env:
       MYSQL_VERSION: 8.0.22
 

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -41,8 +41,8 @@ class BackupStream(threading.Thread):
     state they are switched to active mode on master (& read-only replicate) or kept in observer mode on
     standbys. When a node is promoted it goes via prepare_promotion and promoted modes to active mode."""
 
-    ITERATION_SLEEP = 10
-    REMOTE_POLL_INTERVAL = 240
+    ITERATION_SLEEP = 10.0
+    REMOTE_POLL_INTERVAL = 240.0
 
     @enum.unique
     class Mode(str, enum.Enum):

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -51,11 +51,11 @@ class Controller(threading.Thread):
         # Restore system to given backup
         restore = "restore"
 
-    BACKUP_REFRESH_INTERVAL_BASE = 120
+    BACKUP_REFRESH_INTERVAL_BASE = 120.0
     # We don't expect anyone but the single active MyHoard to make any changes to backups but we still want
     # to sometimes check there aren't some unexpected changes. The "sometimes" can be pretty infrequently
-    BACKUP_REFRESH_ACTIVE_MULTIPLIER = 10
-    ITERATION_SLEEP = 1
+    BACKUP_REFRESH_ACTIVE_MULTIPLIER = 10.0
+    ITERATION_SLEEP = 1.0
 
     def __init__(
         self,

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -397,7 +397,7 @@ class RestoreCoordinator(threading.Thread):
             ranges = list(build_gtid_ranges(read_gtids_from_log(file_name, read_until_time=self.target_time)))
             if ranges:
                 last_range = ranges[-1]
-                until_after_gtids = f"""{last_range["server_uuid"]}:{last_range["end"]}"""
+                until_after_gtids = f'{last_range["server_uuid"]}:{last_range["end"]}'
                 # Don't expect any specific file because if the GTID we're including is the very last entry
                 # in the file the SQL thread might switch to next file and if it is earlier then it won't
                 # so we'd need to be watching for two file names. Because execution is always single threaded

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,14 +1,17 @@
 # Use pip for build requirements to harmonize between OS versions
+coverage
+coveralls
+isort==4.3.21
 mock
-pylint>=2.4.3
+mypy
 pylint-quotes
+pylint>=2.4.3
 pytest
 pytest-mock
 pytest-timeout
 pytest-xdist
-yapf==0.27.0
-isort==4.3.21
-coverage
-coveralls
 responses
+types-PyMySQL
+types-requests
 unify
+yapf==0.27.0

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -205,12 +205,12 @@ def random_basic_string(length=16, *, prefix=None, digit_spacing=None):
         prefix = random.choice(string.ascii_lowercase)
     random_length = length - len(prefix)
     if digit_spacing is None:
-        chars = "".join([random.choice(string.ascii_lowercase + string.digits) for _ in range(random_length)])
+        chars = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(random_length))
     else:
-        chars = "".join([
+        chars = "".join(
             random.choice(string.ascii_lowercase if (n % (digit_spacing + 1)) > 0 else string.digits)
             for n in range(random_length)
-        ])
+        )
     return f"{prefix}{chars}"
 
 

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -348,8 +348,8 @@ def test_3_node_service_failover_and_restore(
             if backup_count > 1:
                 # Do some flushes on master to ensure there are simultaneous binlog uploads and existing ones get reused
                 with mysql_cursor(**master.connect_options) as cursor:
-                    foo_prefix = str(time.time()).replace(".", "_")
-                    cursor.execute(f"CREATE TABLE foo_{foo_prefix} (id INTEGER)")
+                    foo_suffix = str(time.time()).replace(".", "_")
+                    cursor.execute(f"CREATE TABLE foo_{foo_suffix} (id INTEGER)")
                     cursor.execute("COMMIT")
                     cursor.execute("FLUSH BINARY LOGS")
             assert s1controller.backup_streams


### PR DESCRIPTION
We have typechecker enabled in CI, but mypy was not installed.
Added mypy and available type info for PyMySQL and requests.
Modified a few constanst to satisfy type requirements.