### PR TITLE
ci: calm down linter

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,6 +25,7 @@ disable=
     too-many-public-methods,
     too-many-statements,
     ungrouped-imports,
+    unspecified-encoding,
     wrong-import-order,
     wrong-import-position
 

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -460,7 +460,7 @@ class BackupStream(threading.Thread):
     def start_preparing_for_promotion(self):
         with self.lock:
             if self.mode != BackupStream.Mode.observe:
-                raise ValueError("Invalid request to prepare promotion while in mode {}".format(self.mode))
+                raise ValueError(f"Invalid request to prepare promotion while in mode {self.mode}")
 
             self.state_manager.update_state(mode=self.Mode.prepare_promotion)
             self.wakeup_event.set()

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -222,7 +222,7 @@ class BasebackupOperation:
             not self._process_output_line_binlog_info(line) and
             not self._process_output_line_lsn_info(line)
         ):
-            if any(key in line for key in {"[ERROR]", " Failed ", " failed ", " Invalid "}):
+            if any(key in line for key in ["[ERROR]", " Failed ", " failed ", " Invalid "]):
                 self.log.error("xtrabackup: %r", line)
             else:
                 self.log.info("xtrabackup: %r", line)

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -178,23 +178,21 @@ class Controller(threading.Thread):
         with self.lock:
             if self.mode != self.Mode.idle:
                 # Could consider allowing restore request also when mode is `restore`
-                raise ValueError("Current mode is {}, restore only allowed while in idle mode".format(self.mode))
+                raise ValueError(f"Current mode is {self.mode}, restore only allowed while in idle mode")
 
             for backup in list(self.state["backups"]):
                 if backup["stream_id"] != stream_id or backup["site"] != site:
                     continue
                 if not backup["basebackup_info"]:
-                    raise ValueError("Backup {!r} cannot be restored".format(backup))
+                    raise ValueError(f"Backup {backup!r} cannot be restored")
                 if target_time:
                     if target_time < backup["basebackup_info"]["end_ts"]:
-                        raise ValueError(
-                            "Requested target time {} predates backup completion: {!r}".format(target_time, backup)
-                        )
+                        raise ValueError(f"Requested target time {target_time} predates backup completion: {backup!r}")
                     # Caller must make sure they pick a backup that contains the requested target time. If this backup
                     # has been closed (will not get any further updates) at a time that is before the requested target
                     # time it is not possible to satisfy the request
                     if backup["closed_at"] and target_time > backup["closed_at"]:
-                        raise ValueError("Requested target time {} is after backup close: {!r}".format(target_time, backup))
+                        raise ValueError(f"Requested target time {target_time} is after backup close: {backup!r}")
                 break
             else:
                 raise ValueError(f"Requested backup {stream_id!r} for site {site!r} not found")
@@ -242,7 +240,7 @@ class Controller(threading.Thread):
                 elif self.mode == self.Mode.promote:
                     self._handle_mode_promote()
                 else:
-                    assert False, "Invalid mode {}".format(self.mode)
+                    assert False, f"Invalid mode {self.mode}"
                 self.wakeup_event.wait(self._get_iteration_sleep())
                 self.wakeup_event.clear()
             except Exception as ex:  # pylint: disable=broad-except
@@ -707,7 +705,7 @@ class Controller(threading.Thread):
             return
 
         already_processed_remote_indexes = set()
-        for key in {"binlogs_to_fetch", "binlogs_to_apply", "binlogs_applying"}:
+        for key in ["binlogs_to_fetch", "binlogs_to_apply", "binlogs_applying"]:
             for binlog in self.state["promote_details"].get(key, []):
                 already_processed_remote_indexes.add(binlog["remote_index"])
 
@@ -954,7 +952,7 @@ class Controller(threading.Thread):
         self._check_binlog_apply_status()
 
         has_pending = any(
-            self.state["promote_details"].get(key) for key in {"binlogs_to_fetch", "binlogs_to_apply", "binlogs_applying"}
+            self.state["promote_details"].get(key) for key in ["binlogs_to_fetch", "binlogs_to_apply", "binlogs_applying"]
         )
         if not has_pending:
             for stream in self.backup_streams:

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -397,7 +397,7 @@ class RestoreCoordinator(threading.Thread):
             ranges = list(build_gtid_ranges(read_gtids_from_log(file_name, read_until_time=self.target_time)))
             if ranges:
                 last_range = ranges[-1]
-                until_after_gtids = "{}:{}".format(last_range["server_uuid"], last_range["end"])
+                until_after_gtids = f"""{last_range["server_uuid"]}:{last_range["end"]}"""
                 # Don't expect any specific file because if the GTID we're including is the very last entry
                 # in the file the SQL thread might switch to next file and if it is earlier then it won't
                 # so we'd need to be watching for two file names. Because execution is always single threaded

--- a/myhoard/statsd.py
+++ b/myhoard/statsd.py
@@ -125,12 +125,12 @@ class StatsClient:
                         tag_value = tag_value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
                     tag_value = tag_value.isoformat()[:19].replace("-", "").replace(":", "") + "Z"
                 elif isinstance(tag_value, datetime.timedelta):
-                    tag_value = "{}s".format(int(tag_value.total_seconds()))
+                    tag_value = f"{int(tag_value.total_seconds())}s"
                 elif not isinstance(tag_value, str):
                     tag_value = str(tag_value)
                 if " " in tag_value or ":" in tag_value or "|" in tag_value or "=" in tag_value:
                     tag_value = "INVALID"
-                parts.insert(1, ",{}={}".format(tag, tag_value).encode("utf-8"))
+                parts.insert(1, f",{tag}={tag_value}".encode("utf-8"))
 
             if None not in self._dest_addr:
                 self._socket.sendto(b"".join(parts), self._dest_addr)

--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -61,7 +61,8 @@ def atomic_create_file(file_path, *, binary=False, perm=None, uidgid=None, inher
 
 def change_master_to(*, cursor, options):
     """Constructs and executes CHANGE MASTER TO command based on given options"""
-    sql = "CHANGE MASTER TO {}".format(", ".join(f"{k}={v!r}" for k, v in options.items()))
+    option_items = ", ".join(f"{k}={v!r}" for k, v in options.items())
+    sql = f"CHANGE MASTER TO {option_items}"
     cursor.execute(sql)
 
 
@@ -236,8 +237,8 @@ def make_gtid_range_string(ranges):
             if rng[0] == rng[1]:
                 range_strs.append(str(rng[0]))
             else:
-                range_strs.append("{}-{}".format(rng[0], rng[1]))
-        uuid_gnos.append("{}:{}".format(server_uuid, ":".join(range_strs)))
+                range_strs.append(f"{rng[0]}-{rng[1]}")
+        uuid_gnos.append(":".join([server_uuid] + range_strs))
     return ",".join(uuid_gnos)
 
 
@@ -419,7 +420,7 @@ def detect_running_process_id(command):
     output = subprocess.check_output(["ps", "-x", "--cols", "1000", "-o", "pid,command"])
     # We don't expect to have non-ASCII characters, convert using ISO-8859-1, which should always work without raising
     output = output.decode("ISO-8859-1")
-    regex = re.compile(r"^\s*\d+\s+{}".format(re.escape(command)))
+    regex = re.compile(r"^\s*\d+\s+{}".format(re.escape(command)))  # pylint: disable=consider-using-f-string
     ids = [int(line.strip().split()[0]) for line in output.splitlines() if regex.match(line)]
     if not ids or len(ids) > 1:
         return None

--- a/myhoard/web_server.py
+++ b/myhoard/web_server.py
@@ -122,17 +122,18 @@ class WebServer:
     async def status_update(self, request):
         with self._handle_request(name="status_update"):
             body = await self._get_request_json(request)
-            if body.get("mode") == Controller.Mode.active:
+            body_mode = body.get("mode")
+            if body_mode == Controller.Mode.active:
                 force = body.get("force")
                 if not isinstance(force, bool):
                     force = False
                 if force:
                     self.log.info("Switch to active mode with force flag requested")
                 self.controller.switch_to_active_mode(force=force)
-            elif body.get("mode") == Controller.Mode.observe:
+            elif body_mode == Controller.Mode.observe:
                 self.controller.switch_to_observe_mode()
-            elif body.get("mode") == Controller.Mode.restore:
-                for key in {"site", "stream_id"}:
+            elif body_mode == Controller.Mode.restore:
+                for key in ["site", "stream_id"]:
                     if not isinstance(body.get(key), str):
                         raise BadRequest(f"Field {key!r} must be given and a string")
                 if not isinstance(body.get("target_time"), (int, type(None))):
@@ -146,7 +147,7 @@ class WebServer:
                     target_time_approximate_ok=body.get("target_time_approximate_ok"),
                 )
             else:
-                raise BadRequest("Unexpected value {!r} for field 'mode'".format(body.get("mode")))
+                raise BadRequest(f"Unexpected value {body_mode!r} for field 'mode'")
 
             return json_response({"mode": self.controller.mode})
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -205,13 +205,13 @@ def random_basic_string(length=16, *, prefix=None, digit_spacing=None):
         prefix = random.choice(string.ascii_lowercase)
     random_length = length - len(prefix)
     if digit_spacing is None:
-        chars = [random.choice(string.ascii_lowercase + string.digits) for _ in range(random_length)]
+        chars = "".join([random.choice(string.ascii_lowercase + string.digits) for _ in range(random_length)])
     else:
-        chars = [
+        chars = "".join([
             random.choice(string.ascii_lowercase if (n % (digit_spacing + 1)) > 0 else string.digits)
             for n in range(random_length)
-        ]
-    return "{}{}".format(prefix, "".join(chars))
+        ])
+    return f"{prefix}{chars}"
 
 
 def generate_rsa_key_pair(*, bits=3072, public_exponent=65537):

--- a/test/test_basebackup_operation.py
+++ b/test/test_basebackup_operation.py
@@ -23,7 +23,7 @@ def test_basic_backup(mysql_master, extra_uuid):
         # Insert second source_uuid into gtid_executed to test that this is parsed correctly
         if extra_uuid:
             cursor.execute("INSERT INTO mysql.gtid_executed (source_uuid, interval_start, interval_end) "
-                           "VALUES ('{}', 1, 1)".format(extra_uuid))
+                           f"VALUES ('{extra_uuid}', 1, 1)")
             cursor.execute("COMMIT")
 
     if extra_uuid:

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -348,7 +348,8 @@ def test_3_node_service_failover_and_restore(
             if backup_count > 1:
                 # Do some flushes on master to ensure there are simultaneous binlog uploads and existing ones get reused
                 with mysql_cursor(**master.connect_options) as cursor:
-                    cursor.execute("CREATE TABLE foo_{} (id INTEGER)".format(str(time.time()).replace(".", "_")))
+                    foo_prefix = str(time.time()).replace(".", "_")
+                    cursor.execute(f"CREATE TABLE foo_{foo_prefix} (id INTEGER)")
                     cursor.execute("COMMIT")
                     cursor.execute("FLUSH BINARY LOGS")
             assert s1controller.backup_streams


### PR DESCRIPTION
There were a lot of complaints from `make lint` during builds.
This is the attempt to cleanup some:
`C0209: Formatting a regular string which could be a f-string (consider-using-f-string)`

And suppressed for now:
`W1514: Using open without explicitly specifying an encoding (unspecified-encoding)`

