### PR TITLE
Add fix for mysql 8.0.26 [BF-634]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,8 +82,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-    env:
-      MYSQL_VERSION: 8.0.22
+        mysql-version: [8.0.22, 8.0.26]
 
     steps:
 
@@ -101,17 +100,17 @@ jobs:
 
       - id: mysql-repos
         run: |
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-common_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-client_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-server-core_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-server_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-server_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-common_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-server-core_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-server_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-server_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
 
-          sudo dpkg -i mysql-client_$MYSQL_VERSION-1ubuntu18.04_amd64.deb mysql-common_$MYSQL_VERSION-1ubuntu18.04_amd64.deb mysql-community-server-core_$MYSQL_VERSION-1ubuntu18.04_amd64.deb mysql-community-server_$MYSQL_VERSION-1ubuntu18.04_amd64.deb mysql-server_$MYSQL_VERSION-1ubuntu18.04_amd64.deb mysql-community-client_$MYSQL_VERSION-1ubuntu18.04_amd64.deb mysql-community-client-core_$MYSQL_VERSION-1ubuntu18.04_amd64.deb mysql-community-client-plugins_$MYSQL_VERSION-1ubuntu18.04_amd64.deb
+          sudo dpkg -i mysql-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-common_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-server-core_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-server_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-server_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-client-core_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-client-plugins_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
 
       - id: percona-tools
         run: |

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import os
+import re
 import threading
 import time
 
@@ -850,7 +851,8 @@ class Controller(threading.Thread):
             if info["Slave_IO_Running"] == "Yes":
                 raise Exception("Slave IO thread expected to be stopped but is running")
             if info["Slave_SQL_Running"] == "Yes":
-                if info["Slave_SQL_Running_State"] != "Slave has read all relay log; waiting for more updates":
+                if not re.match("(Slave|Replica) has read all relay log; waiting for more updates",
+                                info["Slave_SQL_Running_State"]):
                     raise Exception("Expected SQL thread to be stopped or finished processing updates")
                 cursor.execute("STOP SLAVE SQL_THREAD")
 

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -2,6 +2,7 @@
 import contextlib
 import os
 import random
+import re
 import time
 from typing import List
 from unittest.mock import MagicMock
@@ -397,7 +398,7 @@ def test_3_node_service_failover_and_restore(
                     for cursor in [cursor1, cursor2]:
                         cursor.execute("SHOW SLAVE STATUS")
                         status = cursor.fetchone()["Slave_SQL_Running_State"]
-                        assert status == "Slave has read all relay log; waiting for more updates"
+                        assert re.match("(Slave|Replica) has read all relay log; waiting for more updates", status)
 
                 while_asserts(relay_log_applied, timeout=30)
                 cursor1.execute("STOP SLAVE SQL_THREAD")


### PR DESCRIPTION
Latest MySQL versions return word "Replica" instead of "Slave", thus making incompatible changes.
Match `show slave status` with pattern to support older versions and the latest one.

Also added matrix for MySQL version tests.