### PR TITLE
Treat BrokenPipeError as generic network error

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -1022,7 +1022,13 @@ class BackupStream(threading.Thread):
                 )
             return True
         except (
-            gaierror, GeneralProxyError, ProxyConnectionError, RemoteDisconnected, ServerNotFoundError, SSLEOFError
+            BrokenPipeError,
+            gaierror,
+            GeneralProxyError,
+            ProxyConnectionError,
+            RemoteDisconnected,
+            ServerNotFoundError,
+            SSLEOFError,
         ) as ex:
             self.log.exception("Network error while uploading binlog %s", binlog)
             self.state_manager.increment_counter(name="remote_write_errors")

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -250,7 +250,13 @@ class Controller(threading.Thread):
                 self.wakeup_event.wait(self._get_iteration_sleep())
                 self.wakeup_event.clear()
             except (
-                gaierror, GeneralProxyError, ProxyConnectionError, RemoteDisconnected, ServerNotFoundError, SSLEOFError
+                BrokenPipeError,
+                gaierror,
+                GeneralProxyError,
+                ProxyConnectionError,
+                RemoteDisconnected,
+                ServerNotFoundError,
+                SSLEOFError,
             ) as ex:
                 self.log.exception("Network error while in mode %s", self.mode)
                 self.state_manager.increment_counter(name="errors")


### PR DESCRIPTION
Sometimes network operations fail with this error, no point in
reporting this to sentry.


