### PR TITLE
Draft: Extend CI lint to include pycodestyle

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,6 +100,8 @@ jobs:
 
       - id: mysql-repos
         run: |
+          sudo apt install -y libtinfo5 psmisc perl libnuma1 libmecab2 libaio1
+
           wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
           wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-common_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
           wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb

--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 125

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ typecheck: version
 .PHONY: lint
 lint: version
 	$(PYTHON) -m pylint --rcfile .pylintrc $(PYTHON_SOURCE_DIRS)
+	$(PYTHON) -m pycodestyle --config=.pycodestyle $(PYTHON_SOURCE_DIRS)
 
 .PHONY: fmt
 fmt: version

--- a/myhoard.spec
+++ b/myhoard.spec
@@ -13,6 +13,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-flake8
 BuildRequires:  python3-httplib2
 BuildRequires:  python3-isort
+BuildRequires:  python3-pycodestyle
 BuildRequires:  python3-pylint
 BuildRequires:  python3-PyMySQL >= 0.9.2
 BuildRequires:  python3-pytest

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -217,10 +217,10 @@ class BasebackupOperation:
             line = line.decode("iso-8859-1")
 
         if (
-            not self._process_output_line_new_file(line) and
-            not self._process_output_line_file_finished(line) and
-            not self._process_output_line_binlog_info(line) and
-            not self._process_output_line_lsn_info(line)
+            not self._process_output_line_new_file(line)
+            and not self._process_output_line_file_finished(line)
+            and not self._process_output_line_binlog_info(line)
+            and not self._process_output_line_lsn_info(line)
         ):
             if any(key in line for key in ["[ERROR]", " Failed ", " failed ", " Invalid "]):
                 self.log.error("xtrabackup: %r", line)

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -6,14 +6,14 @@ import logging
 import multiprocessing
 import os
 import queue
-import pymysql
 import threading
 import time
 from contextlib import suppress
-from pymysql import OperationalError
 
+import pymysql
 from pghoard.rohmu import errors as rohmu_errors
 from pghoard.rohmu import get_transfer
+from pymysql import OperationalError
 
 from .append_only_state_manager import AppendOnlyStateManager
 from .backup_stream import BINLOG_BUCKET_SIZE
@@ -22,7 +22,7 @@ from .binlog_downloader import download_binlog
 from .errors import BadRequest
 from .state_manager import StateManager
 from .util import (
-    add_gtid_ranges_to_executed_set, build_gtid_ranges, change_master_to, ERR_TIMEOUT, make_gtid_range_string, mysql_cursor,
+    ERR_TIMEOUT, add_gtid_ranges_to_executed_set, build_gtid_ranges, change_master_to, make_gtid_range_string, mysql_cursor,
     parse_fs_metadata, parse_gtid_range_string, read_gtids_from_log, relay_log_name, rsa_decrypt_bytes,
     sort_and_filter_binlogs, track_rate
 )
@@ -404,9 +404,7 @@ class RestoreCoordinator(threading.Thread):
         if final_round and self.target_time and not self.target_time_approximate_ok and binlogs[-1]["gtid_ranges"]:
             renamed = last_remote_index <= self.state["last_renamed_index"]
             if renamed:
-                file_name = self._relay_log_name(
-                    index=last_remote_index + self.state["binlog_name_offset"]
-                )
+                file_name = self._relay_log_name(index=last_remote_index + self.state["binlog_name_offset"])
             else:
                 file_name = self._relay_log_prefetch_name(index=last_remote_index)
             ranges = list(build_gtid_ranges(read_gtids_from_log(file_name, read_until_time=self.target_time)))

--- a/myhoard/web_server.py
+++ b/myhoard/web_server.py
@@ -9,6 +9,7 @@ import uuid
 
 from aiohttp import web
 from aiohttp.web_response import json_response
+
 from myhoard.backup_stream import BackupStream
 from myhoard.controller import Controller
 from myhoard.errors import BadRequest

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,14 +5,15 @@ httplib2
 isort==4.3.21
 mock
 mypy
+pycodestyle
 pylint-quotes
 pylint>=2.4.3
+PySocks
 pytest
 pytest-mock
 pytest-timeout
 pytest-xdist
 responses
-PySocks
 types-PyMySQL
 types-requests
 unify

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -164,7 +164,7 @@ def restart_mysql(mysql_config, *, with_binlog=True, with_gtids=True):
         command = command + ["--disable-log-bin", "--skip-slave-preserve-commit-order"]
     if not with_gtids:
         command = command + ["--gtid-mode=OFF"]
-    mysql_config.proc = subprocess.Popen(command)   # pylint: disable=consider-using-with
+    mysql_config.proc = subprocess.Popen(command)  # pylint: disable=consider-using-with
     print("Started mysqld with pid", mysql_config.proc.pid)
     wait_for_port(mysql_config.port, wait_time=10)
 

--- a/test/test_append_only_state_manager.py
+++ b/test/test_append_only_state_manager.py
@@ -2,6 +2,7 @@
 import os
 
 import pytest
+
 from myhoard.append_only_state_manager import AppendOnlyStateManager
 
 pytestmark = [pytest.mark.unittest, pytest.mark.all]

--- a/test/test_basebackup_operation.py
+++ b/test/test_basebackup_operation.py
@@ -22,8 +22,10 @@ def test_basic_backup(mysql_master, extra_uuid):
         cursor.execute("COMMIT")
         # Insert second source_uuid into gtid_executed to test that this is parsed correctly
         if extra_uuid:
-            cursor.execute("INSERT INTO mysql.gtid_executed (source_uuid, interval_start, interval_end) "
-                           f"VALUES ('{extra_uuid}', 1, 1)")
+            cursor.execute(
+                "INSERT INTO mysql.gtid_executed (source_uuid, interval_start, interval_end) "
+                f"VALUES ('{extra_uuid}', 1, 1)"
+            )
             cursor.execute("COMMIT")
 
     if extra_uuid:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,8 +4,9 @@ import os
 import subprocess
 from datetime import datetime
 
-import myhoard.util as myhoard_util
 import pytest
+
+import myhoard.util as myhoard_util
 
 from . import generate_rsa_key_pair
 

--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -2,6 +2,7 @@
 import uuid
 
 import pytest
+
 from myhoard.backup_stream import BackupStream
 from myhoard.controller import Controller
 from myhoard.errors import BadRequest


### PR DESCRIPTION
**What?**

- Add pep8 as part of lint step alongside pylint
- Apply pep8 and yapf styling fixes

**Why?**

- Lint step was missing some issues such as whitespace before and after curly braces
- YAPF fixes haven't been applied in a while