### PR TITLE
Build fixes for GH actions runner Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,20 +97,27 @@ jobs:
       - id: remove-default-mysql
         run: |
           sudo apt purge mysql-server mysql-client mysql-common mysql-server-core-* mysql-client-core-*
+          sudo rm -rf /var/lib/mysql
 
       - id: mysql-repos
         run: |
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-common_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-server-core_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-server_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-server_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
-          wget http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/mysql-community-client-plugins_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          VERSION_ID=$(lsb_release -r -s)
 
-          sudo dpkg -i mysql-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-common_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-server-core_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-server_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-server_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-client_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-client-core_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb mysql-community-client-plugins_${{ matrix.mysql-version }}-1ubuntu18.04_amd64.deb
+          mysql_debs=(
+            mysql-community-client-plugins_${{ matrix.mysql-version }}-1ubuntu${VERSION_ID}_amd64.deb
+            mysql-common_${{ matrix.mysql-version }}-1ubuntu${VERSION_ID}_amd64.deb
+            mysql-community-client-core_${{ matrix.mysql-version }}-1ubuntu${VERSION_ID}_amd64.deb
+            mysql-community-client_${{ matrix.mysql-version }}-1ubuntu${VERSION_ID}_amd64.deb
+            mysql-client_${{ matrix.mysql-version }}-1ubuntu${VERSION_ID}_amd64.deb
+            mysql-community-server-core_${{ matrix.mysql-version }}-1ubuntu${VERSION_ID}_amd64.deb
+            mysql-community-server_${{ matrix.mysql-version }}-1ubuntu${VERSION_ID}_amd64.deb
+            mysql-server_${{ matrix.mysql-version }}-1ubuntu${VERSION_ID}_amd64.deb
+          )
+
+          for package in ${mysql_debs[@]}; do
+            wget -q http://repo.mysql.com/apt/ubuntu/pool/mysql-8.0/m/mysql-community/${package}
+            sudo dpkg -i $package
+          done
 
       - id: percona-tools
         run: |


### PR DESCRIPTION
The build process seems to be broken since GitHub actions upgraded to Ubuntu 20.04 and a newer mysql version.

The root cause is that the mysql data directory is a newer version than the build is trying to install and mysql complains that it can't downgrade.

Changes:
- Refactor build to use dynamic ubuntu version
- Cleanup mysql properly