### PR TITLE
Run flake8 during lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-format = abspath
+format = default
 max-line-length = 125
 ignore =
   E123,  # Closing brackets indent

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ typecheck: version
 .PHONY: lint
 lint: version
 	$(PYTHON) -m pylint --rcfile .pylintrc $(PYTHON_SOURCE_DIRS)
+	$(PYTHON) -m flake8 --config .flake8 $(PYTHON_SOURCE_DIRS)
 
 .PHONY: fmt
 fmt: version

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,18 +1,19 @@
 # Use pip for build requirements to harmonize between OS versions
 coverage
 coveralls
+flake8
 httplib2
 isort==4.3.21
 mock
 mypy
 pylint-quotes
 pylint>=2.4.3
+PySocks
 pytest
 pytest-mock
 pytest-timeout
 pytest-xdist
 responses
-PySocks
 types-PyMySQL
 types-requests
 unify


### PR DESCRIPTION
Some linting issues were being missed by not running flake8 during lint. Additionally, the flake8 config had an invalid option preventing it running correctly (`format = abspath`).

See https://github.com/aiven/myhoard/pull/64#discussion_r742344914 for an example of an issue that would have been good for the lint CI step to pick up.

With this change, the issue above would have been caught:
```
myhoard/controller.py:235:17: E201 whitespace after '{'
myhoard/controller.py:235:58: E202 whitespace before '}'
```