### PR TITLE
add mysql 8.0.27 to the test matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        mysql-version: [8.0.22, 8.0.26]
+        mysql-version: [8.0.22, 8.0.26, 8.0.27]
 
     steps:
 


### PR DESCRIPTION
# About this change: What it does, why it matters

We want to test myhoard with more recent versions of mysql.

This does not include 8.0.28 yet since percona-xtrabackup is not available for that version.


