### PR TITLE
 enable codecov for myhoard repository

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,4 +139,9 @@ jobs:
           pip install -e .
 
       - id: unittest
-        run: make unittest
+        run: make coverage
+
+      - id: upload-codecov
+        uses: codecov/codecov-action@v2
+        with:
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *~
 /.cache
 /.coverage
+coverage.xml
 /.project
 /.pydevproject
 /.vagrant

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ copyright:
 
 .PHONY: coverage
 coverage: version
-	$(PYTHON) -m pytest $(PYTEST_ARG) --cov-report term-missing --cov myhoard test/
+	$(PYTHON) -m pytest $(PYTEST_ARG) --cov-report term-missing --cov-branch \
+		--cov-report xml:coverage.xml --cov myhoard test/
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MyHoard [![Build Status](https://github.com/aiven/myhoard/workflows/Build%20MyHoard/badge.svg?branch=master)](https://github.com/aiven/myhoard/actions)
+MyHoard [![Build Status](https://github.com/aiven/myhoard/workflows/Build%20MyHoard/badge.svg?branch=master)](https://github.com/aiven/myhoard/actions) [![Codecov](https://codecov.io/gh/aiven/myhoard/branch/main/graph/badge.svg?token=nLr7M7hvCx)](https://codecov.io/gh/aiven/myhoard)
 =====================================================================================================================
 
 MyHoard is a daemon for creating, managing and restoring MySQL backups.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        # advanced settings
+        if_ci_failed: error  # success, failure, error, ignore
+        only_pulls: false
+        if_not_found: failure

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -10,6 +10,7 @@ pylint-quotes
 pylint>=2.4.3
 PySocks
 pytest
+pytest-cov==3.0.0
 pytest-mock
 pytest-timeout
 pytest-xdist


### PR DESCRIPTION
# About this change: What it does, why it matters

The goal of this PR is to enable codecov in this repository.

    Start generating coverage reports
    Upload reports in CI
    Add badge with codecov

Add the following simple settings as a start point that we can improve later on:

        threshold: 0%
        # advanced settings
        if_ci_failed: error  # success, failure, error, ignore
        only_pulls: false
        if_not_found: failure



