### PR TITLE
Harden the GitHub Workflows [SECDEV-674]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Build MyHoard
 
+permissions: read-all
+
 on:
   push:
     branches:
@@ -22,6 +24,8 @@ jobs:
 
       - id: checkout-code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - id: prepare-python
         uses: actions/setup-python@v2


### PR DESCRIPTION
This patch improves security around GitHub Workflows:

For the `build.yml` workflow:

 * Set the default workflow permissions to `read` - because this workflow does not need to modify anything in the project.
 * Do not let `actions/checkout` persist (write to disk) the GitHub token - because this workflow does not need to modify anything in the project. And prevents other actions to look at the token.

The other workflows only use trusted (GitHub) actions - no changes were made.