### PR TITLE
Use python3-rohmu library instead of pghoard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ __pycache__/
 *.orig
 Dockerfile.myhoard-test-temp
 .vscode/
+myhoard/version.py

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Requirements
 MyHoard requires Python 3.6 or later and some additional components to operate:
 
 * [percona-xtrabackup](https://github.com/percona/percona-xtrabackup)
-* [pghoard](https://github.com/aiven/pghoard)
 * [python3-PyMySQL](https://github.com/PyMySQL/PyMySQL)
+* [python3-rohmu](https://github.com/aiven/rohmu)
 * [MySQL server 8.x+](https://www.oracle.com/mysql/)
 
 Currently MyHoard only works on Linux and expects MySQL service to be managed

--- a/myhoard.spec
+++ b/myhoard.spec
@@ -7,7 +7,6 @@ BuildArch:      noarch
 License:        ASL 2.0
 Source0:        myhoard-rpm-src.tar
 BuildRequires:  percona-xtrabackup-80 >= 8.0
-BuildRequires:  pghoard >= 2.0.0-115
 BuildRequires:  python3-aiohttp
 BuildRequires:  python3-devel
 BuildRequires:  python3-flake8
@@ -18,14 +17,15 @@ BuildRequires:  python3-PyMySQL >= 0.9.2
 BuildRequires:  python3-pytest
 BuildRequires:  python3-pytest-cov
 BuildRequires:  python3-requests
+BuildRequires:  python3-rohmu
 BuildRequires:  python3-socks
 BuildRequires:  python3-yapf
 BuildRequires:  rpm-build
 Requires:       percona-xtrabackup-80 >= 8.0
-Requires:       pghoard >= 2.0.0-115
 Requires:       python3-aiohttp
 Requires:       python3-cryptography >= 0.8
 Requires:       python3-PyMySQL >= 0.9.2
+Requires:       python3-rohmu >= 1.0.2
 Requires:       systemd
 
 %undefine _missing_build_ids_terminate_build

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -22,10 +22,10 @@ from contextlib import suppress
 from datetime import datetime, timezone
 from http.client import RemoteDisconnected
 from httplib2 import ServerNotFoundError
-from pghoard.rohmu import errors as rohmu_errors
-from pghoard.rohmu.compressor import CompressionStream
-from pghoard.rohmu.encryptor import EncryptorStream
-from pghoard.rohmu.object_storage.s3 import S3Transfer
+from rohmu import errors as rohmu_errors
+from rohmu.compressor import CompressionStream
+from rohmu.encryptor import EncryptorStream
+from rohmu.object_storage.s3 import S3Transfer
 from socket import gaierror
 from socks import GeneralProxyError, ProxyConnectionError
 from ssl import SSLEOFError

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from contextlib import suppress
 from myhoard.errors import XtraBackupError
-from pghoard.common import increase_pipe_capacity, set_stream_nonblocking
+from rohmu.util import increase_pipe_capacity, set_stream_nonblocking
 
 import base64
 import logging

--- a/myhoard/basebackup_restore_operation.py
+++ b/myhoard/basebackup_restore_operation.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from contextlib import suppress
-from pghoard.common import increase_pipe_capacity, set_stream_nonblocking
+from rohmu.util import increase_pipe_capacity, set_stream_nonblocking
 
 import base64
 import fnmatch

--- a/myhoard/binlog_downloader.py
+++ b/myhoard/binlog_downloader.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
-from pghoard.rohmu import get_transfer
-from pghoard.rohmu.compressor import DecompressSink
-from pghoard.rohmu.encryptor import DecryptSink
+from rohmu import get_transfer
+from rohmu.compressor import DecompressSink
+from rohmu.encryptor import DecryptSink
 
 import contextlib
 import logging

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -16,9 +16,9 @@ from .util import (
 )
 from http.client import RemoteDisconnected
 from httplib2 import ServerNotFoundError
-from pghoard.rohmu import get_transfer
-from pghoard.rohmu.compressor import DecompressSink
-from pghoard.rohmu.encryptor import DecryptSink
+from rohmu import get_transfer
+from rohmu.compressor import DecompressSink
+from rohmu.encryptor import DecryptSink
 from socket import gaierror
 from socks import GeneralProxyError, ProxyConnectionError
 from ssl import SSLEOFError

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -21,7 +21,7 @@ from .util import (
     track_rate,
 )
 from contextlib import suppress
-from pghoard.rohmu import errors as rohmu_errors, get_transfer
+from rohmu import errors as rohmu_errors, get_transfer
 from pymysql import OperationalError
 
 import contextlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ botocore
 cryptography >= 0.8
 httplib2
 paramiko
-pghoard >= 2.1.0
 PyMySQL >= 0.9.2
 PySocks
+rohmu >= 1.0.2

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(
     packages=find_packages(exclude=["test"]),
     install_requires=[
         "cryptography",
-        "pghoard",
         "PyMySQL",
+        "rohmu",
     ],
     extras_require={},
     dependency_links=[],

--- a/test/test_backup_stream.py
+++ b/test/test_backup_stream.py
@@ -3,7 +3,7 @@ from . import build_statsd_client, generate_rsa_key_pair, MySQLConfig, wait_for_
 from myhoard.backup_stream import BackupStream
 from myhoard.binlog_scanner import BinlogScanner
 from myhoard.controller import Controller
-from pghoard.rohmu.object_storage.local import LocalTransfer
+from rohmu.object_storage.local import LocalTransfer
 
 import json
 import myhoard.util as myhoard_util

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -3,7 +3,7 @@ from . import build_statsd_client, DataGenerator, generate_rsa_key_pair, restart
 from myhoard.backup_stream import BackupStream
 from myhoard.binlog_scanner import BinlogScanner
 from myhoard.restore_coordinator import RestoreCoordinator
-from pghoard.rohmu.object_storage.local import LocalTransfer
+from rohmu.object_storage.local import LocalTransfer
 from unittest.mock import Mock, patch
 
 import myhoard.util as myhoard_util


### PR DESCRIPTION
The [rohmu project](https://github.com/aiven/rohmu) was recently split from its parent project, [pghoard](https://github.com/aiven/pghoard). As myhoard relies on rohmu for performing backup tasks (object storage upload/download, compression, encryption), the package dependency must be updated. 

Resolves aiven/rohmu issue [#7](https://github.com/aiven/rohmu/issues/7)