### PR TITLE
Prevent restores from continuing indefinitely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__/
 /.venv/
 *.orig
 Dockerfile.myhoard-test-temp
+.vscode/

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -1176,7 +1176,11 @@ class RestoreCoordinator(threading.Thread):
             current_index = int(current_file.rsplit(".", 1)[-1])
             if expected_index is not None and current_index < expected_index:
                 self.log.debug("Expected relay log name not reached (%r < %r)", current_index, expected_index)
-                if sql_running_state == "Slave has read all relay log; waiting for more updates":
+                sql_running_states = (
+                    "Slave has read all relay log; waiting for more updates",
+                    "Replica has read all relay log; waiting for more updates"
+                )
+                if sql_running_state in sql_running_states:
                     # Sometimes if the next file is empty MySQL SQL thread does not update the relay log
                     # file to match the last one. Because the thread has finished doing anything we need
                     # to react to the situation or else restoration will stall indefinitely.


### PR DESCRIPTION
# About this change: What it does, why it matters

In mysql versions greater than 8.0.26, the default terminology changed. See WL#14189 and WL#14628. The Slave_SQL_Running_State message has changed to use Replica instead of Slave. This change ensures that
myhoard can handle both terms.


See
https://dev.mysql.com/worklog/task/?id=14189
https://dev.mysql.com/worklog/task/?id=14628

 https://github.com/mysql/mysql-server/commit/2e273ed403827fa3d86970b40280d4fe9d154c43



