### PR TITLE
Add missing build dependency `systemd-rpm-macros` into rpm spec file

### DIFF
--- a/myhoard.spec
+++ b/myhoard.spec
@@ -21,6 +21,7 @@ BuildRequires:  python3-rohmu
 BuildRequires:  python3-socks
 BuildRequires:  python3-yapf
 BuildRequires:  rpm-build
+BuildRequires:  systemd-rpm-macros
 Requires:       percona-xtrabackup-80 >= 8.0
 Requires:       python3-aiohttp
 Requires:       python3-cryptography >= 0.8


### PR DESCRIPTION
RPM package build requires `systemd-rpm-macros` which is missing in the spec file. So adding it.