### PR TITLE
Report binlog_upload_delay to better track problems with binlog uploads

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -258,6 +258,19 @@ class BackupStream(threading.Thread):
             return 0
 
     @property
+    def binlog_upload_delay(self) -> int:
+        """Returns the number of seconds since the oldest pending binlog was written."""
+        now = time.time()
+        oldest_mtime = now
+        for binlog in self.state["pending_binlogs"]:
+            try:
+                oldest_mtime = min(oldest_mtime, os.stat(binlog["full_name"]).st_mtime)
+            except FileNotFoundError:
+                pass  # binlog was just purged, so ignore it.
+
+        return int(now - oldest_mtime)
+
+    @property
     def created_at(self):
         return self.state["created_at"]
 

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1410,6 +1410,11 @@ class Controller(threading.Thread):
         self.stats.gauge_float("myhoard.binlog_upload_age_min", min(binlog_upload_ages))
         self.stats.gauge_float("myhoard.binlog_upload_age_max", max(binlog_upload_ages))
 
+        # Send additional info about how long 'complete' binlog files have been waiting to be uploaded
+        binlog_upload_delays = [backup_stream.binlog_upload_delay for backup_stream in backup_streams]
+        self.stats.gauge_int("myhoard.binlog_upload_delay_min", min(binlog_upload_delays))
+        self.stats.gauge_int("myhoard.binlog_upload_delay_max", max(binlog_upload_delays))
+
     def _set_uploaded_binlog_references(self):
         references = self.state["uploaded_binlogs"]
         for reference in references:


### PR DESCRIPTION
This adds a `binlog_upload_delay` property of `BackupStreams` to report a value of 0 when there are no eligible binlogs to stream. If there are pending binlogs, it reports the maximum age of these files, based on their `mtime`.

This metric will assist in identifying problems with transferring pending binlogs, as the existing `binlog_upload_age` metric will reach arbitrarily high values even when no binlogs are available for upload.

