### PR TITLE
Emit binlog upload rate metric to statsd

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -12,6 +12,7 @@ from .util import (
     make_gtid_range_string,
     mysql_cursor,
     parse_fs_metadata,
+    RateTracker,
     relay_log_name,
 )
 from http.client import RemoteDisconnected
@@ -60,6 +61,7 @@ class Controller(threading.Thread):
     # We don't expect anyone but the single active MyHoard to make any changes to backups but we still want
     # to sometimes check there aren't some unexpected changes. The "sometimes" can be pretty infrequently
     BACKUP_REFRESH_ACTIVE_MULTIPLIER = 10.0
+    BINLOG_TRANSFER_RATE_CALCULATION_WINDOW = 30.0
     ITERATION_SLEEP = 1.0
 
     def __init__(
@@ -82,12 +84,23 @@ class Controller(threading.Thread):
         temp_dir,
     ):
         super().__init__()
+        self.log = logging.getLogger(self.__class__.__name__)
         self.backup_refresh_interval_base = self.BACKUP_REFRESH_INTERVAL_BASE
         self.backup_settings = backup_settings
         self.backup_sites = backup_sites
         self.backup_streams = []
         self.backup_streams_initialized = False
         self.binlog_not_caught_log_counter = 0
+        self.binlog_progress_tracker = (
+            RateTracker(
+                stats=stats,
+                log=self.log,
+                metric_name="myhoard.backup_stream.binlog_upload_rate",
+                window=self.BINLOG_TRANSFER_RATE_CALCULATION_WINDOW,
+            )
+            if stats
+            else None
+        )
         self.binlog_purge_settings = binlog_purge_settings
         scanner_state_file = os.path.join(state_dir, "binlog_scanner_state.json")
         self.binlog_scanner = BinlogScanner(
@@ -99,7 +112,6 @@ class Controller(threading.Thread):
         self.is_running = True
         self.iteration_sleep = self.ITERATION_SLEEP
         self.lock = threading.RLock()
-        self.log = logging.getLogger(self.__class__.__name__)
         self.max_binlog_bytes = None
         self.mysql_client_params = mysql_client_params
         self.mysql_config_file_name = mysql_config_file_name
@@ -238,6 +250,8 @@ class Controller(threading.Thread):
     def run(self):
         self.log.info("Controller running")
         consecutive_unexpected_errors = 0
+        if self.binlog_progress_tracker:
+            self.binlog_progress_tracker.start()
         while self.is_running:
             try:
                 if self.mode == self.Mode.idle:
@@ -290,6 +304,8 @@ class Controller(threading.Thread):
             self.restore_coordinator.stop()
         for stream in self.backup_streams:
             stream.stop()
+        if self.binlog_progress_tracker:
+            self.binlog_progress_tracker.stop()
         self.log.info("Controller stopped")
 
     def switch_to_active_mode(self, *, force=False):
@@ -594,6 +610,7 @@ class Controller(threading.Thread):
         # data stored in local state file if available or in backup file storage if local state is not available
         return BackupStream(
             backup_reason=None,
+            binlog_progress_tracker=self.binlog_progress_tracker,
             compression=backup_site.get("compression"),
             file_storage_setup_fn=lambda: get_transfer(backup_site["object_storage"]),
             file_uploaded_callback=self._binlog_uploaded,
@@ -1437,6 +1454,7 @@ class Controller(threading.Thread):
         site_id, backup_site = self._get_upload_backup_site()
         stream = BackupStream(
             backup_reason=backup_reason,
+            binlog_progress_tracker=self.binlog_progress_tracker,
             binlogs=self.binlog_scanner.binlogs,
             compression=backup_site.get("compression"),
             file_storage_setup_fn=lambda: get_transfer(backup_site["object_storage"]),

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -21,8 +21,8 @@ from .util import (
     track_rate,
 )
 from contextlib import suppress
-from rohmu import errors as rohmu_errors, get_transfer
 from pymysql import OperationalError
+from rohmu import errors as rohmu_errors, get_transfer
 
 import contextlib
 import enum
@@ -1170,7 +1170,7 @@ class RestoreCoordinator(threading.Thread):
 
         # Try to start SQL thread with an incremental delay
         if self.sql_thread_restart_count > 0:
-            factor = 1.5 ** self.sql_thread_restart_count
+            factor = 1.5**self.sql_thread_restart_count
             iteration_delay = min(self.SQL_THREAD_RESTART_INIT_INTERVAL * factor, self.SQL_THREAD_RESTART_MAX_INTERVAL)
             if self.sql_thread_restart_time is not None:
                 time_passed = time.monotonic() - self.sql_thread_restart_time


### PR DESCRIPTION
Usually, binlogs are relatively small and the time taken to upload to S3 is negligible. However, in some situations (e.g. long-running transactions), binlogs will not be finalised as quickly, leading both to larger binlog files, as well as greater time increments between successive binlogs. This in itself is not a problem, but the existing metrics do not make it easy to differentiate between long-running transactions, and actual problems with processing binlogs.

One part of a robust solution involves exposing a metric which provides assurance that the S3 upload is occurring, even if the biglog is taking a while to be transferred. With this present, an alerting system can ignore metrics relating to binlogs not being sent if the current transfer rate is above a certain threshold.

The impementation involves the creation of a long-running thread, attached to the controller. This allows for a single metric to be emitted which collates all binlog transfers across all `BackupStream` instances. The pre-existing `trace_rate` function is limited in a few ways, both regarding not handling low transfer speeds, as well as performing crude bitrate calculations based on successive data points.
