### PR TITLE
Transmit metric on backup initiation

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -463,6 +463,7 @@ class BackupStream(threading.Thread):
                     if self.state["closed_info"] and self.active_phase != self.ActivePhase.none:
                         self._handle_pending_mark_as_closed()
                     if self.active_phase == self.ActivePhase.basebackup:
+                        self.stats.gauge_int("myhoard.backup_stream.basebackup_requested", 1)
                         self._take_basebackup()
                     if self.is_streaming_binlogs():
                         self._upload_binlogs()


### PR DESCRIPTION
This will assist in more easily monitoring basebackups. By sending a metric as soon as the basebackup creation process begins, it can be used to reconcile subsequent activity, ensuring that it is closely followed by basebackup progress metrics.
