### PR TITLE
Run OPTMIZE TABLE on mysql >= 8.0.29

### DIFF
--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -456,6 +456,15 @@ def relay_log_name(*, prefix, index, full_path=True):
     return name
 
 
+def get_mysql_version(cursor: pymysql.cursors.DictCursor) -> Optional[str]:
+    cursor.execute("SELECT @@GLOBAL.version AS mysql_version")
+    row = cursor.fetchone()
+    if row is not None and "mysql_version" in row:
+        return row["mysql_version"]
+    else:
+        return None
+
+
 def track_rate(*, current, last_recorded, last_recorded_time, metric_name, min_increase=1_000_000, stats):
     """Calculates rate of change given current value and previously handled value and time. If there is
     a relevant change (as defined by min_increase) and some time has passed, the current rate of change


### PR DESCRIPTION
Due to changes in the underlying mysql version, it may be required to run OPTIMIZE TABLE on tables which have been ALTERed, to prevent coprruption.

xtrabackup detects this situation and reports which tables are impacted, so myhoard simply needs to carry out this operation.

Initial patch by: Nick Farrell

Obsoletes: https://github.com/aiven/myhoard/pull/101