### PR TITLE
Publish to PyPI with GitHub Action

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,48 @@
+# Based on https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Publish to PyPI
+
+permissions: read-all
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  build-n-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.10
+
+    - name: Install pypa/build
+      run: >-
+        python -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Verify tag is annotated
+      if: startsWith(github.ref, 'refs/tags')
+      run: >-
+        test $(git for-each-ref --format='%(objecttype)' ${GITHUB_REF}) == tag
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295 # v1.5.0
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The project is not currently published to PyPI which makes it impossible to use in a standard virtual environment setup.
This PR adds a GitHub Action that publishes sdist and wheel to PyPI based on pushed annotated tag. The code is copied from the [aiven-client action](https://github.com/aiven/aiven-client/blob/main/.github/workflows/publish-pypi.yaml).

The secret `secrets.PYPI_API_TOKEN` needs to be set up. Could someone please help me with that? Thank you!