### PR TITLE
Nicois/sre 5264 relaxed timeout during optimize

### DIFF
--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -155,20 +155,18 @@ class BasebackupOperation:
                 if not row:
                     break
                 db_and_table = row["NAME"].split("/")
-                table_info = {
-                    "database": unescape_to_utf8(db_and_table[0]),
-                    "table": unescape_to_utf8(db_and_table[1]),
-                }
-                if table_info["database"] is None or table_info["table"] is None:
+                database = unescape_to_utf8(db_and_table[0])
+                table = unescape_to_utf8(db_and_table[1])
+                if database is None or table is None:
                     self.log.warning("Could not decode database/table name of '%s'", row["NAME"])
                     continue
-                database_and_tables.append(table_info)
+                database_and_tables.append((database, table))
 
-            for database_and_table in database_and_tables:
+            for database, table in database_and_tables:
                 self.stats.increase(metric="myhoard.basebackup.optimize_table")
-                self.log.info("Optimizing table %r", database_and_table)
+                self.log.info("Optimizing table %r.%r", database, table)
                 # sending it as parameters doesn't work
-                cursor.execute(f"OPTIMIZE TABLE `{database_and_table['database']}`.`{database_and_table['table']}`")
+                cursor.execute(f"OPTIMIZE TABLE `{database}`.`{table}`")
                 cursor.execute("COMMIT")
 
     def _get_data_directory_size(self):

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -150,7 +150,10 @@ class BasebackupOperation:
 
             database_and_tables = []
             cursor.execute("SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE TOTAL_ROW_VERSIONS > 0")
-            for row in cursor.fetchall():
+            while True:
+                row = cursor.fetchone()
+                if not row:
+                    break
                 db_and_table = row["NAME"].split("/")
                 table_info = {
                     "database": unescape_to_utf8(db_and_table[0]),


### PR DESCRIPTION
As part of the workaround for xtrabackup incompatibility with altered tables with the latest version of mysql, myhoard scans the list of table names and runs OPTIMIZE TABLE on each of them, prior to each basebackup.

Some mysql services have many table name, taking well over the default timeout to return that list. 

Modify the mysql cursor’s timeout during this optimise operation, without altering other timeouts.

Additional minor changes are made to stream back the list of tables to myhoard, and to use a simpler variable structure.