### PR TITLE
Make running optimize for MySQL 8.0.30 optional

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -99,6 +99,7 @@ class BackupStream(threading.Thread):
         mysql_config_file_name,
         mysql_data_directory,
         normalized_backup_time,
+        optimize_tables_before_backup=False,
         rsa_public_key_pem,
         remote_binlogs_state_file,
         server_id,
@@ -129,6 +130,7 @@ class BackupStream(threading.Thread):
         self.mysql_client_params = mysql_client_params
         self.mysql_config_file_name = mysql_config_file_name
         self.mysql_data_directory = mysql_data_directory
+        self.optimize_tables_before_backup = optimize_tables_before_backup
         self.binlog_progress_tracker = binlog_progress_tracker
         # Keep track of remote binlogs so that we can drop binlogs containing only GTID
         # ranges that have already been backed up from our list of pending binlogs
@@ -823,6 +825,7 @@ class BackupStream(threading.Thread):
             stats=self.stats,
             stream_handler=self._basebackup_stream_handler,
             temp_dir=self.temp_dir,
+            optimize_tables_before_backup=self.optimize_tables_before_backup,
         )
         try:
             self.basebackup_operation.create_backup()

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -40,6 +40,7 @@ class BasebackupOperation:
         mysql_client_params,
         mysql_config_file_name,
         mysql_data_directory,
+        optimize_tables_before_backup=False,
         progress_callback=None,
         stats,
         stream_handler,
@@ -60,6 +61,7 @@ class BasebackupOperation:
             self.mysql_config = config.read()
         self.mysql_data_directory = mysql_data_directory
         self.number_of_files = 0
+        self.optimize_tables_before_backup = optimize_tables_before_backup
         self.proc = None
         self.processed_original_bytes = 0
         self.progress_callback = progress_callback
@@ -76,7 +78,8 @@ class BasebackupOperation:
         self.abort_reason = None
         self.data_directory_size_start, self.data_directory_filtered_size = self._get_data_directory_size()
         self._update_progress()
-        self._optimize_tables()
+        if self.optimize_tables_before_backup:
+            self._optimize_tables()
 
         # Write encryption key to file to avoid having it on command line. NamedTemporaryFile has mode 0600
         with tempfile.NamedTemporaryFile(

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -77,6 +77,7 @@ class Controller(threading.Thread):
         mysql_data_directory,
         mysql_relay_log_index_file,
         mysql_relay_log_prefix,
+        optimize_tables_before_backup=False,
         restart_mysqld_callback,
         restore_max_binlog_bytes,
         server_id,
@@ -119,6 +120,7 @@ class Controller(threading.Thread):
         self.mysql_data_directory = mysql_data_directory
         self.mysql_relay_log_index_file = mysql_relay_log_index_file
         self.mysql_relay_log_prefix = mysql_relay_log_prefix
+        self.optimize_tables_before_backup = optimize_tables_before_backup
         self.restart_mysqld_callback = restart_mysqld_callback
         self.restore_max_binlog_bytes = restore_max_binlog_bytes
         self.restore_coordinator = None
@@ -622,6 +624,7 @@ class Controller(threading.Thread):
             mysql_config_file_name=self.mysql_config_file_name,
             mysql_data_directory=self.mysql_data_directory,
             normalized_backup_time=None,
+            optimize_tables_before_backup=self.optimize_tables_before_backup,
             rsa_public_key_pem=backup_site["encryption_keys"]["public"],
             remote_binlogs_state_file=self._remote_binlogs_state_file_from_stream_id(stream_id),
             server_id=self.server_id,
@@ -1474,6 +1477,7 @@ class Controller(threading.Thread):
             mysql_config_file_name=self.mysql_config_file_name,
             mysql_data_directory=self.mysql_data_directory,
             normalized_backup_time=normalized_backup_time,
+            optimize_tables_before_backup=self.optimize_tables_before_backup,
             rsa_public_key_pem=backup_site["encryption_keys"]["public"],
             remote_binlogs_state_file=self._remote_binlogs_state_file_from_stream_id(stream_id),
             server_id=self.server_id,

--- a/myhoard/myhoard.py
+++ b/myhoard/myhoard.py
@@ -201,6 +201,7 @@ class MyHoard:
             mysql_data_directory=mysql["data_directory"],
             mysql_relay_log_index_file=mysql["relay_log_index_file"],
             mysql_relay_log_prefix=mysql["relay_log_prefix"],
+            optimize_tables_before_backup=self.config.get("optimize_tables_before_backup", False),
             restart_mysqld_callback=self._restart_mysqld,
             restore_max_binlog_bytes=self.config["restore_max_binlog_bytes"],
             server_id=self.config["server_id"],

--- a/test/test_basebackup_operation.py
+++ b/test/test_basebackup_operation.py
@@ -171,6 +171,7 @@ def test_backup_with_non_optimized_tables(mysql_master: MySQLConfig) -> None:
         mysql_client_params=mysql_master.connect_options,
         mysql_config_file_name=mysql_master.config_name,
         mysql_data_directory=mysql_master.config_options.datadir,
+        optimize_tables_before_backup=True,
         progress_callback=None,
         stats=build_statsd_client(),
         stream_handler=stream_handler,


### PR DESCRIPTION
This is disabled by default and can be enabled with a new option: `optimize_tables_before_backup`.

# About this change: What it does, why it matters

The operation can be slow on very large databases and is rarely needed, default to making it optional.
