### PR TITLE
Improve Debian/Ubuntu install instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ build-dep-fedora:
 		--exclude=mariadb-server "$(MYSQL_SERVER_PACKAGE)"
 
 
+.PHONY: build-dep-ubuntu
+build-dep-ubuntu:
+	sudo apt install -y lsb-release wget tzdata libsnappy-dev libpq5 libpq-dev software-properties-common build-essential rsync curl git libaio1 libmecab2 psmisc python-is-python3
 
 # local development, don't use in CI
 # prerequisite

--- a/README.md
+++ b/README.md
@@ -762,30 +762,34 @@ make PYTEST_ARGS="-k test_3_node_service_failover_and_restore" dockertest-pytest
 
 Running native tests must NOT be performed as root (requires additional options for mysql)
 
-# Test environment setup: Ubuntu 20.04
+# Test environment setup: Debian/Ubuntu
 
 Run:
 
 ```bash
-sudo apt-get install -y lsb-release wget tzdata libsnappy-dev libpq5 libpq-dev software-properties-common build-essential rsync curl git libaio1 libmecab2 psmisc
+MYSQL_VERSION=8.0.29
+PERCONA_VERSION=8.0.29-22-1.bullseye
+make build-dep-ubuntu
 make clean
-sudo scripts/remove-default-mysql
-sudo scripts/install-mysql-packages ${MYSQL_VERSION}
-sudo scripts/setup-percona-repo
-sudo scripts/install-percona-package ${PERCONA_VERSION}
+scripts/remove-default-mysql
+scripts/install-mysql-packages ${MYSQL_VERSION}
+scripts/setup-percona-repo
+scripts/install-percona-package ${PERCONA_VERSION}
 scripts/install-python-deps
-sudo scripts/create-user
-RUN python -m pip install -e .
+pip3 install -e .
 ```
 
-this command will install all the required package version. Please note: the state of your environment
+Note that since Percona-xtrabackup does not work with a version of MySQL newer
+than Percona-xtrabackup, the version strings should match.
+
+This command will install all the required package version. Please note: the state of your environment
 WILL change with this command. Both native and Python packages will be installed.
 
 # Test environment setup: Fedora
 
 run:
 
-`sudo make build-dep-fedora`
+`make build-dep-fedora`
 
 (this can install or change packages on your host system)
 

--- a/scripts/install-mysql-packages
+++ b/scripts/install-mysql-packages
@@ -9,11 +9,20 @@ sudo debconf-set-selections <<< 'mysql-community-server mysql-server/default-aut
 
 rm -f mysql-*.deb
 
-export VERSION_ID="$(lsb_release -r -s)"
-if [[ "$VERSION_ID" = *.* ]] ; then
+VENDOR="$(dpkg-vendor --query Vendor)"
+if [[ "${VENDOR}" = Ubuntu ]]; then
     DIST="ubuntu"
-else
+    VERSION_ID=$"$(lsb_release -r -s)"
+elif [[ "${VENDOR}" = "Debian" ]]; then
     DIST="debian"
+    VERSION_ID=$"$(lsb_release -r -s)"
+    if [[ "${VERSION_ID}" = "n/a" ]]; then
+        # Fall back to latest stable version on sid/testing
+        VERSION_ID="$(distro-info -r --stable)"
+    fi
+else
+    echo "Unknown vendor ${VENDOR}"
+    exit 1
 fi
 
 export mysql_debs=(

--- a/scripts/setup-percona-repo
+++ b/scripts/setup-percona-repo
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-export VERSION_NAME="$(lsb_release -sc)"
+export VERSION_NAME=${VERSION_NAME:-"$(lsb_release -sc)"}
 export DEBIAN_FRONTEND="noninteractive"
 wget https://repo.percona.com/apt/percona-release_latest."${VERSION_NAME}"_all.deb
 set +e


### PR DESCRIPTION
Drive-by fix to instructions to allow running MyHoard on Debian/Ubuntu:

* Don't run scripts with sudo - they already call sudo when necessary
* When running on sid/testing (for which no packages are published), install stable packages
* Drop 'RUN' prefix which was presumably copied from a Dockerfile
* Allow overriding VERSION_ID
* Factor out 'make build-dep-ubuntu', for consistency with Fedora