### PR TITLE
Fix tests by switching GitHub actions back to Ubuntu 20.04.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # only use one version for the lint step
@@ -74,7 +74,7 @@ jobs:
         run: make copyright
 
   unittest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       # this isn't a standard matrix because some version testing doesn't make sense


### PR DESCRIPTION
As of recently, "ubuntu-latest" has changed from being "ubuntu-20.04" to "ubuntu-22.04". However, no MySQL 8.0.26 packages are available for that version which breaks the GitHub actions. See https://github.com/actions/runner-images/issues/6399

Moving back to Ubuntu 22.04 fixes the GitHub action, allowing us to move to Ubuntu 22.04 or a mix of versions at our leisure.