### PR TITLE
Use GitHub matrix strategy to allow custom ubuntu version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,7 +74,7 @@ jobs:
         run: make copyright
 
   unittest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-${{ matrix.ubuntu-version }}
     strategy:
       fail-fast: false
       # this isn't a standard matrix because some version testing doesn't make sense
@@ -85,36 +85,47 @@ jobs:
           - mysql-version: "8.0.26"
             percona-version: "8.0.27-19-1.focal"
             python-version: "3.9"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.26"
             percona-version: "8.0.28-20-1.focal"
             python-version: "3.9"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.27"
             percona-version: "8.0.27-19-1.focal"
             python-version: "3.9"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.27"
             percona-version: "8.0.27-19-1.focal"
             python-version: "3.10"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.27"
             percona-version: "8.0.27-19-1.focal"
             python-version: "3.11"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.27"
             percona-version: "8.0.28-21-1.focal"
             python-version: "3.9"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.27"
             percona-version: "8.0.28-21-1.focal"
             python-version: "3.11"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.28"
             percona-version: "8.0.28-21-1.focal"
             python-version: "3.9"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.28"
             percona-version: "8.0.28-21-1.focal"
             python-version: "3.11"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.30"
             percona-version: "8.0.30-23-1.focal"
             python-version: "3.9"
+            ubuntu-version: "20.04"
           - mysql-version: "8.0.30"
             percona-version: "8.0.30-23-1.focal"
             python-version: "3.11"
+            ubuntu-version: "20.04"
 
     steps:
       - id: checkout-code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # only use one version for the lint step
@@ -74,7 +74,7 @@ jobs:
         run: make copyright
 
   unittest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       # this isn't a standard matrix because some version testing doesn't make sense


### PR DESCRIPTION
Set the ubuntu version in the strategy matrix, along with other versions.

This allows e.g. running some tests on Ubuntu 20.04 and some on 22.04. This is useful because not all percona and mysql versions are available for all Ubuntu versions.