### PR TITLE
Add typing for all of myhoard and enable check_untyped_defs

### DIFF
--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -54,8 +54,8 @@ class BasebackupOperation:
         self.binlog_info = None
         self.current_file = None
         self.data_directory_filtered_size = None
-        self.data_directory_size_end = None
-        self.data_directory_size_start = None
+        self.data_directory_size_end: Optional[int] = None
+        self.data_directory_size_start: Optional[int] = None
         self.encryption_algorithm = encryption_algorithm
         self.encryption_key = encryption_key
         self.log = logging.getLogger(self.__class__.__name__)

--- a/myhoard/binlog_scanner.py
+++ b/myhoard/binlog_scanner.py
@@ -18,7 +18,7 @@ class BinlogInfo(TypedDict):
     local_index: int
     processed_at: float
     processing_time: float
-    server_id: str
+    server_id: int
 
 
 class BinlogScanner:
@@ -33,7 +33,7 @@ class BinlogScanner:
         total_binlog_count: int
         total_binlog_size: int
 
-    def __init__(self, *, binlog_prefix: str, server_id: str, state_file, stats):
+    def __init__(self, *, binlog_prefix: str, server_id: int, state_file, stats):
         super().__init__()
         binlogs: List[BinlogInfo] = []
         lock = threading.RLock()
@@ -131,7 +131,7 @@ class BinlogScanner:
         """Scan for any removed binlogs. Passes any removed binlogs to the given callback function
         before updating internal state."""
         removed_size = 0
-        removed = []
+        removed: List[BinlogInfo] = []
 
         try:
             with self.lock:

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -60,6 +60,11 @@ class PendingBinlogInfo(TypedDict):
     remote_index: int
 
 
+class BinlogStream(TypedDict):
+    site: str
+    stream_id: str
+
+
 class RestoreCoordinator(threading.Thread):
     """Restores an existing backup. Starts by restoring the basebackup and then applies
     necessary binlogs on top of that.
@@ -145,7 +150,7 @@ class RestoreCoordinator(threading.Thread):
     def __init__(
         self,
         *,
-        binlog_streams,
+        binlog_streams: List[BinlogStream],
         file_storage_config,
         max_binlog_bytes=None,
         mysql_client_params,
@@ -159,7 +164,7 @@ class RestoreCoordinator(threading.Thread):
         site: str,
         state_file: str,
         stats: StatsClient,
-        stream_id: int,
+        stream_id: str,
         target_time=None,
         target_time_approximate_ok=None,
         temp_dir: str,
@@ -255,7 +260,7 @@ class RestoreCoordinator(threading.Thread):
         self.sql_thread_restart_count = 0
         self.sql_thread_restart_time: Optional[float] = None
 
-    def add_new_binlog_streams(self, new_binlog_streams: List[PendingBinlogInfo]) -> bool:
+    def add_new_binlog_streams(self, new_binlog_streams: List[BinlogStream]) -> bool:
         if not self.can_add_binlog_streams():
             return False
         self.binlog_streams = self.binlog_streams + new_binlog_streams

--- a/myhoard/web_server.py
+++ b/myhoard/web_server.py
@@ -187,6 +187,7 @@ class WebServer:
     async def stop(self):
         if not self.site:
             return
+        assert self.runner is not None
         self.log.info("Stopping web server")
         await self.runner.cleanup()
         self.log.info("Web server stopped")

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,3 +15,4 @@ ignore_missing_imports = True
 
 [mypy-systemd]
 ignore_missing_imports = True
+check_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     extras_require={},
     dependency_links=[],
-    package_data={},
+    package_data={"myhoard": ["py.typed"]},
     entry_points={
         "console_scripts": [
             "myhoard = myhoard.myhoard:main",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,7 @@ from . import (
     MySQLConfig,
     random_basic_string,
 )
+from myhoard.controller import Controller
 from myhoard.util import atomic_create_file, change_master_to, mysql_cursor, wait_for_port
 from myhoard.web_server import WebServer
 from typing import Optional
@@ -257,6 +258,7 @@ def fixture_default_backup_site(session_tmpdir, encryption_keys):
 @pytest.fixture(scope="function", name="master_controller")
 def fixture_master_controller(session_tmpdir, mysql_master, default_backup_site):
     controller = build_controller(
+        Controller,
         default_backup_site=default_backup_site,
         mysql_config=mysql_master,
         session_tmpdir=session_tmpdir,
@@ -270,6 +272,7 @@ def fixture_master_controller(session_tmpdir, mysql_master, default_backup_site)
 @pytest.fixture(scope="function", name="standby1_controller")
 def fixture_standby1_controller(session_tmpdir, mysql_standby1, default_backup_site):
     controller = build_controller(
+        Controller,
         default_backup_site=default_backup_site,
         mysql_config=mysql_standby1,
         session_tmpdir=session_tmpdir,
@@ -283,6 +286,7 @@ def fixture_standby1_controller(session_tmpdir, mysql_standby1, default_backup_s
 @pytest.fixture(scope="function", name="standby2_controller")
 def fixture_standby2_controller(session_tmpdir, mysql_standby2, default_backup_site):
     controller = build_controller(
+        Controller,
         default_backup_site=default_backup_site,
         mysql_config=mysql_standby2,
         session_tmpdir=session_tmpdir,

--- a/test/test_backup_stream.py
+++ b/test/test_backup_stream.py
@@ -2,8 +2,9 @@
 from . import build_statsd_client, generate_rsa_key_pair, MySQLConfig, wait_for_condition
 from myhoard.backup_stream import BackupStream
 from myhoard.binlog_scanner import BinlogScanner
-from myhoard.controller import Controller
+from myhoard.controller import BackupSiteInfo, Controller
 from rohmu.object_storage.local import LocalTransfer
+from typing import Dict
 
 import json
 import myhoard.util as myhoard_util
@@ -131,7 +132,7 @@ def _run_backup_stream_test(session_tmpdir, mysql_master: MySQLConfig, backup_st
         with open(state_file) as f:
             assert bs.state == json.load(f)
 
-        backup_sites = {
+        backup_sites: Dict[str, BackupSiteInfo] = {
             "default": {
                 "recovery_only": False,
                 "encryption_keys": {},

--- a/test/test_backup_stream.py
+++ b/test/test_backup_stream.py
@@ -61,6 +61,8 @@ def _run_backup_stream_test(session_tmpdir, mysql_master: MySQLConfig, backup_st
         temp_dir=mysql_master.base_dir,
     )
 
+    assert mysql_master.server_id is not None
+
     scanner = BinlogScanner(
         binlog_prefix=mysql_master.config_options.binlog_file_prefix,
         server_id=mysql_master.server_id,
@@ -131,10 +133,12 @@ def _run_backup_stream_test(session_tmpdir, mysql_master: MySQLConfig, backup_st
 
         backup_sites = {
             "default": {
+                "recovery_only": False,
+                "encryption_keys": {},
                 "object_storage": {
                     "directory": backup_target_location,
                     "storage_type": "local",
-                }
+                },
             }
         }
         backups = Controller.get_backup_list(backup_sites)


### PR DESCRIPTION
I've added some asserts to make mypy happy; these all check internal constraints, rather than external expectations. Happy to add more extended descriptions to them, if deemed useful - but I think most of them are fairly clear if we ever trigger them.

TypedDict doesn't have a derived type for its keys yet and I didn't want to add a static Literal for each TypedDict that we have to keep up to date, so there's some additional "type: ignore"s for now. See also https://github.com/python/mypy/issues/11553