### PR TITLE
Track when the SQL thread is restarted unexpectedly

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -17,6 +17,7 @@ from .util import (
     parse_fs_metadata,
     RateTracker,
     relay_log_name,
+    restart_unexpected_dead_sql_thread,
 )
 from http.client import RemoteDisconnected
 from httplib2 import ServerNotFoundError
@@ -742,8 +743,7 @@ class Controller(threading.Thread):
                 else:
                     sql_thread_running = slave_status["Slave_SQL_Running"]
                     if sql_thread_running != "Yes":
-                        self.log.warning("Expected SQL thread to be running state is %s, starting it", sql_thread_running)
-                        cursor.execute("START SLAVE SQL_THREAD")
+                        restart_unexpected_dead_sql_thread(cursor, slave_status, self.stats, self.log)
                     return
             else:
                 self.log.info("Expected relay log (%r) and GTIDs reached (%r)", expected_file, expected_ranges)

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -18,6 +18,7 @@ from .util import (
     parse_gtid_range_string,
     read_gtids_from_log,
     relay_log_name,
+    restart_unexpected_dead_sql_thread,
     rsa_decrypt_bytes,
     SlaveStatus,
     sort_and_filter_binlogs,
@@ -1185,10 +1186,9 @@ class RestoreCoordinator(threading.Thread):
                     return
 
         self.sql_thread_restart_time = time.monotonic()
-        self.log.warning("SQL thread is not running. Running 'START SLAVE SQL_THREAD'")
         self.sql_thread_restart_count += 1
         with self._mysql_cursor() as cursor:
-            cursor.execute("START SLAVE SQL_THREAD")
+            restart_unexpected_dead_sql_thread(cursor, slave_status, self.stats, self.log)
 
     def _check_sql_slave_status(self) -> tuple[bool, int]:
         expected_range = self.state["current_executed_gtid_target"]

--- a/myhoard/statsd.py
+++ b/myhoard/statsd.py
@@ -81,7 +81,7 @@ class StatsClient:
             raise ValueError(f"Invalid int value for {metric}: {value!r}")
         self._send(metric, b"g", int(value), tags)
 
-    def increase(self, metric: str, inc_value=1, tags=None) -> None:
+    def increase(self, metric: str, inc_value: int = 1, tags=None) -> None:
         self._send(metric, b"c", inc_value, tags)
 
     def timing(self, metric: str, value: Union[float, int, datetime.timedelta], tags=None) -> None:


### PR DESCRIPTION
When a SQL thread has died and is revived:

* log the last reason for why the SQL thread died
* count the number of restarts in a metric, along with the errno