### PR TITLE
Handle race with BackupStream's normalized_backup_time being None [BF-1754]

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1056,10 +1056,16 @@ class Controller(threading.Thread):
 
     def _mark_periodic_backup_requested_if_interval_exceeded(self):
         normalized_backup_time = self._current_normalized_backup_timestamp()
-        last_normalized_backup_time = None
         most_recent_scheduled = None
+        last_normalized_backup_time = None
         if self.backup_streams:
-            last_normalized_backup_time = max(stream.state["normalized_backup_time"] for stream in self.backup_streams)
+            normalized_backup_times = [
+                stream.state["normalized_backup_time"]
+                for stream in self.backup_streams
+                if stream.state["normalized_backup_time"]
+            ]
+            if normalized_backup_times:
+                last_normalized_backup_time = max(normalized_backup_times)
             scheduled_streams = [
                 stream
                 for stream in self.backup_streams


### PR DESCRIPTION
If `Controller._mark_periodic_backup_requested_if_interval_exceeded` gets called in between a BackupStream being created (`myhoard/controller.py:626`) and it loading its basebackup info (`myhoard/basebackup_stream.py:571`), myhoard crashes with the following traceback:

```
Oct 19 22:12:28 aivenprod-n3120506 myhoard[4167496]: Traceback (most recent call last):
Oct 19 22:12:28 aivenprod-n3120506 myhoard[4167496]:   File "/usr/lib/python3.9/site-packages/myhoard/controller.py", line 263, in run
Oct 19 22:12:28 aivenprod-n3120506 myhoard[4167496]:     self._handle_mode_active()
Oct 19 22:12:28 aivenprod-n3120506 myhoard[4167496]:   File "/usr/lib/python3.9/site-packages/myhoard/controller.py", line 981, in _handle_mode_active
Oct 19 22:12:28 aivenprod-n3120506 myhoard[4167496]:     self._mark_periodic_backup_requested_if_interval_exceeded()
Oct 19 22:12:28 aivenprod-n3120506 myhoard[4167496]:   File "/usr/lib/python3.9/site-packages/myhoard/controller.py", line 1059, in _mark_periodic_backup_requested_if_interval_exceeded
Oct 19 22:12:28 aivenprod-n3120506 myhoard[4167496]:     last_normalized_backup_time = max(stream.state["normalized_backup_time"] for stream in self.backup_streams)
Oct 19 22:12:28 aivenprod-n3120506 myhoard[4167496]: TypeError: '>' not supported between instances of 'NoneType' and 'str'
```

It's hard to write a meaningful unit test for this, but with typing added (see my other PRs) mypy will actually complain:

```
myhoard/controller.py:1115: error: Value of type variable "SupportsRichComparisonT" of "max" cannot be "Optional[str]"
```