### PR TITLE
Fix for failing backup when GTID executed line is too long [BF-1449]

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,6 +57,7 @@ jobs:
 
       - id: build-deps
         run: |
+          sudo apt-get update
           sudo apt install -y libsnappy-dev
           sudo apt-get install -q -y --allow-unauthenticated -o Dpkg::Options::=--force-confnew mysql-server percona-xtrabackup-80
           mysqld --version


### PR DESCRIPTION
# About this change: What it does, why it matters

When a base backup is finished we parse the output of `xtrabackup` to get the information about the binary logs wrt to this backup, this information is used by backup streams to check if binlog is needed for the backup or could be skipped.

If this information is missing, there might be side effects, such as e.g. a new backup stream might think that a pending binlog (which is about to be purged) is needed by a new backup, even though a new backup binlog position is newer than this binlog.
So the problem is that we expect that the output line of `xtrabackup` always includes the complete GTID executed line, that's not always the case. The max length of log line in `xtrabackup` is 8192, thus it will truncate lines with lots of GTID executed entries to this length, which causes parsing issues and binlog info missing.
    
The fix is to get rid of parsing binlog information from the log, instead - fetch information from extra meta file, which should be more reliable.


