### PR TITLE
Consume all output when xtrabackup dies

### DIFF
--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -222,12 +222,12 @@ class BasebackupOperation:
                     raise Exception(f"Operation abort requested: {self.abort_reason}")
 
             pending_output += self.proc.stderr.read() or b""
-            if exit_code == 0 and pending_output:
+            if exit_code is not None and pending_output:
                 for line in pending_output.splitlines():
                     self._process_output_line(line)
             # Process has exited but reader thread might still be processing stdout. Wait for
             # the thread to exit before proceeding
-            if exit_code == 0:
+            if exit_code is not None:
                 self.log.info("Process has exited, joining reader thread")
                 reader_thread.join()
                 reader_thread = None


### PR DESCRIPTION
Previously the stream reader thread would be unceremoniously interrupted if xtrabackup failed with an error, and pending stderr output would be discarded.

This gives it a chance to consistently consume any error output from xtrabackup, and hides a confusing exception when the stream reader thread tries to read from a closed file.
