### PR TITLE
statemanager: add typing

### DIFF
--- a/myhoard/state_manager.py
+++ b/myhoard/state_manager.py
@@ -17,7 +17,7 @@ class StateManager(Generic[T]):
 
     state: T
 
-    def __init__(self, *, allow_unknown_keys=False, lock=None, state: T, state_file):
+    def __init__(self, *, allow_unknown_keys: bool = False, lock=None, state: T, state_file):
         self.allow_unknown_keys = allow_unknown_keys
         self.lock = lock or threading.RLock()
         self.state = state
@@ -32,36 +32,36 @@ class StateManager(Generic[T]):
         self.state_file = state_file
         self.read_state()
 
-    def delete_state(self):
+    def delete_state(self) -> None:
         if os.path.exists(self.state_file):
             os.remove(self.state_file)
 
-    def increment_counter(self, *, name, increment=1):
+    def increment_counter(self, *, name: str, increment: int = 1) -> None:
         with self.lock:
             assert name in self.state
-            self.state[name] = self.state[name] + increment
+            self.state[name] = self.state[name] + increment  # type: ignore
             self.write_state()
 
-    def read_state(self):
+    def read_state(self) -> None:
         if os.path.exists(self.state_file):
             with open(self.state_file, "r") as f:
-                self.state.clear()
-                self.state.update(**json.load(f))
+                self.state.clear()  # type: ignore
+                self.state.update(**json.load(f))  # type: ignore
         else:
             self.write_state()
 
-    def update_state(self, **kwargs):
+    def update_state(self, **kwargs) -> None:
         with self.lock:
             changes = False
             for name, value in kwargs.items():
                 if not self.allow_unknown_keys:
                     assert name in self.state
                 if self.state.get(name) != value:
-                    self.state[name] = value
+                    self.state[name] = value  # type: ignore
                     changes = True
             if changes:
                 self.write_state()
 
-    def write_state(self):
+    def write_state(self) -> None:
         with atomic_create_file(self.state_file) as f:
             json.dump(self.state, f)

--- a/test/test_append_only_state_manager.py
+++ b/test/test_append_only_state_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from myhoard.append_only_state_manager import AppendOnlyStateManager
+from typing import Dict, List
 
 import os
 import pytest
@@ -9,7 +10,7 @@ pytestmark = [pytest.mark.unittest, pytest.mark.all]
 
 def test_basic_operations(session_tmpdir):
     state_file_name = os.path.join(session_tmpdir().strpath, "aosm.txt")
-    entries = []
+    entries: List[Dict] = []
     aosm = AppendOnlyStateManager(entries=entries, state_file=state_file_name)
     assert aosm.entries == []
     file_size = os.stat(state_file_name).st_size
@@ -36,7 +37,7 @@ def test_basic_operations(session_tmpdir):
     assert new_file_size > file_size
     file_size = new_file_size
 
-    entries2 = []
+    entries2: List[Dict] = []
     AppendOnlyStateManager(entries=entries2, state_file=state_file_name)
 
     assert set(entry["foo"] for entry in entries) == {f"bar{index}" for index in range(1000, 1011)}


### PR DESCRIPTION
TypedDict doesn't have a derived type for its keys yet and I didn't want to add a static Literal for each TypedDict that we have to keep up to date, so there's some additional "type: ignore"s for now. See also python/mypy#11553
