### PR TITLE
Report progressing of basebackup

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -908,6 +908,7 @@ class BackupStream(threading.Thread):
             # use longer than normal timeout here with multiple retries and increasing timeout.
             connect_params = dict(self.mysql_client_params)
             for retry, multiplier in [(True, 1), (True, 2), (False, 3)]:
+                self.stats.gauge_int("myhoard.basebackup.progressing", 1)
                 try:
                     connect_params["timeout"] = DEFAULT_MYSQL_TIMEOUT * 5 * multiplier
                     with mysql_cursor(**connect_params) as cursor:

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -296,6 +296,8 @@ class BasebackupOperation:
         except UnicodeDecodeError:
             line = line.decode("iso-8859-1")
 
+        self.stats.gauge_int("myhoard.basebackup.progressing", 1)
+
         if (
             not self._process_output_line_new_file(line)
             and not self._process_output_line_file_finished(line)


### PR DESCRIPTION
# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)

When xtrabackup is working, it is constantly emitting logs similar to
  `2023-01-27T00:28:00.109513-00:00 1 [Note] [MY-011825] [Xtrabackup] >> log scanned up to (9125452372)`
every second.

If xtrabackup is still emitting logs, it can be considered the base backup is still progressing, and thus can be utilized in alerting suppression on a super large database.

(Originated from Aiven internal ticket SRE-5535)