### PR TITLE
Support backup intervals greater than 24 hours

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -17,5 +17,6 @@ pytest-mock
 pytest-timeout
 pytest-xdist
 responses
+time-machine
 types-PyMySQL
 types-requests


### PR DESCRIPTION
Enables backup scheduling for intervals greater than 24 hours. This mainly changes the way we calculate the `_current_normalized_backup_timestamp` by considering the previous normalized backup timestamp.