### PR TITLE
Fix CI by updating pre-commit config hooks' versions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,18 @@
 [flake8]
 max-line-length = 125
+
+# E123: Closing brackets indent
+# E126: Hanging indents
+# E129: Visual indent
+# E203: Whitespace before ':' (in accordance with Black)
+# E231: Missing whitespace after ',' (in accordance with Black)
+# E501: Max line length
+# E722: do not use bare 'except'
 extend-ignore =
-  E123,  # Closing brackets indent
-  E126,  # Hanging indents
-  E129,  # Visual indent
-  E203,  # Whitespace before ':' (in accordance with Black)
-  E231,  # Missing whitespace after ',' (in accordance with Black)
-  E501,  # Max line length
-  E722,  # bare-except
+  E123,
+  E126,
+  E129,
+  E203,
+  E231,
+  E501,
+  E722

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-pylint
@@ -19,7 +19,7 @@ repos:
     -   id: pylint
         args: [--disable=E0401]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.0.0
     hooks:
     -   id: mypy
         args: [--ignore-missing-imports]

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -47,12 +47,10 @@ ERR_BACKUP_IN_PROGRESS = 4085
 
 
 class BaseBackup(TypedDict):
-
     end_ts: float
 
 
 class Backup(TypedDict):
-
     basebackup_info: BaseBackup
     closed_at: Optional[float]
     completed_at: Optional[float]
@@ -63,7 +61,6 @@ class Backup(TypedDict):
 
 
 class BackupRequest(TypedDict):
-
     backup_reason: BackupStream.BackupReason
     normalized_backup_time: str
 

--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -611,7 +611,6 @@ class RateTracker(threading.Thread):
 
 
 class SlaveStatus(TypedDict):
-
     Relay_Log_File: str
     Relay_Master_Log_File: str
     Exec_Master_Log_Pos: int

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -340,7 +340,6 @@ def test_empty_last_relay(running_state, session_tmpdir, mysql_master, mysql_emp
     mock_cursor.fetchone.return_value = slave_status_response
 
     with patch.object(RestoreCoordinator, "_mysql_cursor") as mock_mysql_cursor:
-
         mock_mysql_cursor.return_value.__enter__.return_value = mock_cursor
         mock_cursor.foo.return_value.bar.return_value.something.return_value = "bar"
         mock_cursor.foo.return_value = "bar"


### PR DESCRIPTION
An isort and poetry incompatibility leads to the pipeline being broken. Also update mypy and the other linters and pass all checks.

### About this change: What it does, why it matters

Fixes main which was blocked in the ``pre-commit run`` stage