### PR TITLE
Allow rebuilding tables before restoring binlogs

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -271,6 +271,7 @@ class Controller(threading.Thread):
     def restore_backup(
         self,
         *,
+        rebuild_tables: bool = False,
         site: str,
         stream_id: str,
         target_time: Optional[float] = None,
@@ -314,6 +315,7 @@ class Controller(threading.Thread):
                         }
                     ],
                     "pending_binlogs_state_file": self._get_restore_coordinator_pending_state_file_and_remove_old(),
+                    "rebuild_tables": rebuild_tables,
                     "state_file": self._get_restore_coordinator_state_file_and_remove_old(),
                     "stream_id": stream_id,
                     "site": site,
@@ -823,6 +825,7 @@ class Controller(threading.Thread):
             mysql_relay_log_index_file=self.mysql_relay_log_index_file,
             mysql_relay_log_prefix=self.mysql_relay_log_prefix,
             pending_binlogs_state_file=options["pending_binlogs_state_file"],
+            rebuild_tables=options["rebuild_tables"],
             restart_mysqld_callback=self.restart_mysqld_callback,
             rsa_private_key_pem=backup_site["encryption_keys"]["private"],
             site=options["site"],
@@ -1636,6 +1639,7 @@ class Controller(threading.Thread):
                     ]
                     + options["binlog_streams"],
                     "pending_binlogs_state_file": self._get_restore_coordinator_pending_state_file_and_remove_old(),
+                    "rebuild_tables": options["rebuild_tables"],
                     "state_file": self._get_restore_coordinator_state_file_and_remove_old(),
                     "stream_id": earlier_backup["stream_id"],
                     "site": earlier_backup["site"],

--- a/myhoard/table.py
+++ b/myhoard/table.py
@@ -1,0 +1,36 @@
+#  Copyright (c) 23 Aiven, Helsinki, Finland. https://aiven.io/
+from typing import Any, Mapping, Tuple
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class Table:
+    table_schema: str
+    table_name: str
+    table_rows: int
+    avg_row_length: int
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, Any]) -> "Table":
+        return Table(
+            table_schema=row["TABLE_SCHEMA"],
+            table_name=row["TABLE_NAME"],
+            table_rows=row["TABLE_ROWS"],
+            avg_row_length=row["AVG_ROW_LENGTH"],
+        )
+
+    def sort_key(self) -> Tuple[str, str]:
+        return self.table_schema, self.table_name
+
+    def estimated_size_bytes(self) -> int:
+        return self.table_rows * self.avg_row_length
+
+    def escaped_designator(self) -> str:
+        escaped_table_schema = escape_identifier(self.table_schema)
+        escaped_table_name = escape_identifier(self.table_name)
+        return f"{escaped_table_schema}.{escaped_table_name}"
+
+
+def escape_identifier(name: str) -> str:
+    return "`" + name.replace("`", "``") + "`"

--- a/myhoard/web_server.py
+++ b/myhoard/web_server.py
@@ -133,6 +133,8 @@ class WebServer:
             elif body_mode == Controller.Mode.observe:
                 self.controller.switch_to_observe_mode()
             elif body_mode == Controller.Mode.restore:
+                if not isinstance(body.get("rebuild_tables"), (bool, type(None))):
+                    raise BadRequest("Field 'rebuild_tables' must be a boolean when present")
                 for key in ["site", "stream_id"]:
                     if not isinstance(body.get(key), str):
                         raise BadRequest(f"Field {key!r} must be given and a string")
@@ -141,6 +143,7 @@ class WebServer:
                 if not isinstance(body.get("target_time_approximate_ok"), (bool, type(None))):
                     raise BadRequest("Field 'target_time_approximate_ok' must be a boolean when present")
                 self.controller.restore_backup(
+                    rebuild_tables=False if body.get("rebuild_tables") is None else body.get("rebuild_tables"),
                     site=body["site"],
                     stream_id=body["stream_id"],
                     target_time=body.get("target_time"),

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -1,0 +1,38 @@
+#  Copyright (c) 23 Aiven, Helsinki, Finland. https://aiven.io/
+from myhoard.table import escape_identifier, Table
+
+
+def test_create_table_from_row() -> None:
+    table = Table.from_row(
+        {
+            "TABLE_SCHEMA": "schema",
+            "TABLE_NAME": "name",
+            "TABLE_ROWS": 123456,
+            "AVG_ROW_LENGTH": 100,
+        }
+    )
+    assert table.table_schema == "schema"
+    assert table.table_name == "name"
+    assert table.table_rows == 123456
+    assert table.avg_row_length == 100
+
+
+def test_table_sort_key() -> None:
+    table = Table(table_schema="schema", table_name="name", table_rows=10, avg_row_length=20)
+    assert table.sort_key() == ("schema", "name")
+
+
+def test_table_estimated_size_bytes() -> None:
+    table = Table(table_schema="schema", table_name="name", table_rows=10, avg_row_length=20)
+    assert table.estimated_size_bytes() == 200
+
+
+def test_table_escaped_designator() -> None:
+    table = Table(table_schema="bad`sch``ema", table_name="bad`name", table_rows=10, avg_row_length=20)
+    assert table.escaped_designator() == "`bad``sch````ema`.`bad``name`"
+
+
+def test_escape_identifier() -> None:
+    assert escape_identifier("name") == "`name`"
+    assert escape_identifier("na`me") == "`na``me`"
+    assert escape_identifier("na``me") == "`na````me`"

--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -138,6 +138,14 @@ async def test_status_update_to_restore(master_controller, web_client):
     )
     assert response["message"] == "Field 'target_time' must be an integer when present"
 
+    response = await put_and_verify_json_body(
+        web_client,
+        "/status",
+        {"mode": "restore", "rebuild_tables": "foo", "site": "default", "stream_id": "abc"},
+        expected_status=400,
+    )
+    assert response["message"] == "Field 'rebuild_tables' must be a boolean when present"
+
     async def restore_status_returned():
         response = await get_and_verify_json_body(web_client, "/status/restore")
         assert isinstance(response["basebackup_compressed_bytes_downloaded"], int)


### PR DESCRIPTION
# About this change: What it does, why it matters

This can avoid data corruption caused by multiple bugs in MySQL 8.0.30+ when updating from an earlier version.