### PR TITLE
controller: don't request new backup if we're already at the maximum

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1151,6 +1151,12 @@ class Controller(threading.Thread):
         normalized_backup_time = self._current_normalized_backup_timestamp()
         most_recent_scheduled = None
         last_normalized_backup_time = None
+        last_completed_backup_time = self.completed_backups[-1]["completed_at"] if self.completed_backups else None
+
+        # If we already have a recent enough backup, skip for now.
+        if last_completed_backup_time and datetime.datetime.fromtimestamp(last_completed_backup_time).isoformat() > normalized_backup_time:
+            return
+
         if self.backup_streams:
             normalized_backup_times = [
                 stream.state["normalized_backup_time"]


### PR DESCRIPTION
# About this change: What it does, why it matters

Currently if we get a bunch of backups for whatever reason, this wave pattern is amplified by the way we request backups. 

This PR attempts to fix that by not requesting a scheduled backup if we're already over the maximum count, which should short-circuit this wave.
