### PR TITLE
mark basebackups as broken when restore fails

### DIFF
--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -71,7 +71,16 @@ async def test_backup_list(master_controller, web_client):
         assert response["backups"]
         assert len(response["backups"]) == 1
         backup = response["backups"][0]
-        expected = {"basebackup_info", "closed_at", "completed_at", "recovery_site", "resumable", "site", "stream_id"}
+        expected = {
+            "basebackup_info",
+            "broken_at",
+            "closed_at",
+            "completed_at",
+            "recovery_site",
+            "resumable",
+            "site",
+            "stream_id",
+        }
         assert set(backup) == expected
 
     await awhile_asserts(has_backup)


### PR DESCRIPTION
Will close PR: https://github.com/aiven/myhoard/pull/143

Following @rikonen idea about marking basebackups as broken instead of having a target time for basebackups. Will create a ticket for marking/unmarking basebackups as broken via API request.