### PR TITLE
Fix rebuild_tables on large tables and after reloading myhoard

### DIFF
--- a/myhoard/table.py
+++ b/myhoard/table.py
@@ -1,5 +1,5 @@
 #  Copyright (c) 23 Aiven, Helsinki, Finland. https://aiven.io/
-from typing import Any, Mapping, Tuple
+from typing import Any, Mapping
 
 import dataclasses
 
@@ -19,9 +19,6 @@ class Table:
             table_rows=row["TABLE_ROWS"],
             avg_row_length=row["AVG_ROW_LENGTH"],
         )
-
-    def sort_key(self) -> Tuple[str, str]:
-        return self.table_schema, self.table_name
 
     def estimated_size_bytes(self) -> int:
         return self.table_rows * self.avg_row_length

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -318,9 +318,9 @@ def _restore_coordinator_sequence(
         assert rc.state["restore_errors"] == 1
         # FailingStateManager is configured to fail once on t1, so it will retry t1.
         # If resume is correctly implemented, it won't retry t0
-        assert rc.state_manager.update_log.count({"last_rebuilt_table": ("db1", "t0")}) == 1
-        assert rc.state_manager.update_log.count({"last_rebuilt_table": ("db1", "t1")}) == 2
-        assert rc.state_manager.update_log.count({"last_rebuilt_table": ("db1", "t2")}) == 1
+        assert rc.state_manager.update_log.count({"last_rebuilt_table": "`db1`.`t0`"}) == 1
+        assert rc.state_manager.update_log.count({"last_rebuilt_table": "`db1`.`t1`"}) == 2
+        assert rc.state_manager.update_log.count({"last_rebuilt_table": "`db1`.`t2`"}) == 1
     else:
         assert rc.state["restore_errors"] == 0
     assert rc.state["remote_read_errors"] == 0
@@ -424,6 +424,6 @@ class FailingStateManager(Generic[T], StateManager[T]):
         super().update_state(**kwargs)
         # We're not testing "what if the StateManager fails", but using it as an injection
         # mechanism to stop at interesting points, that's why we raise after writing the state.
-        if not self.has_failed and kwargs.get("last_rebuilt_table") == ("db1", "t1"):
+        if not self.has_failed and kwargs.get("last_rebuilt_table") == "`db1`.`t1`":
             self.has_failed = True
             raise InjectedError()

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -17,11 +17,6 @@ def test_create_table_from_row() -> None:
     assert table.avg_row_length == 100
 
 
-def test_table_sort_key() -> None:
-    table = Table(table_schema="schema", table_name="name", table_rows=10, avg_row_length=20)
-    assert table.sort_key() == ("schema", "name")
-
-
 def test_table_estimated_size_bytes() -> None:
     table = Table(table_schema="schema", table_name="name", table_rows=10, avg_row_length=20)
     assert table.estimated_size_bytes() == 200


### PR DESCRIPTION
Two bugs prevent the operation from succeeding :
- On large tables, we timeout before the operation is complete,
- After a restart, the state type is not as expected and the operation can't resume.