### PR TITLE
Add ability to delete individual backups

### DIFF
--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from . import awhile_asserts, while_asserts
+from functools import partial
 from myhoard.backup_stream import BackupStream
-from myhoard.controller import Controller
+from myhoard.controller import Backup, Controller
 from myhoard.errors import BadRequest
 from myhoard.restore_coordinator import RestoreCoordinator
 from myhoard.web_server import WebServer
+from urllib import parse
 
 import pytest
 import uuid
@@ -71,10 +73,121 @@ async def test_backup_list(master_controller, web_client):
         assert response["backups"]
         assert len(response["backups"]) == 1
         backup = response["backups"][0]
-        expected = {"basebackup_info", "closed_at", "completed_at", "recovery_site", "resumable", "site", "stream_id"}
+        expected = {
+            "basebackup_info",
+            "closed_at",
+            "completed_at",
+            "delete_requested_at",
+            "recovery_site",
+            "resumable",
+            "site",
+            "stream_id",
+        }
         assert set(backup) == expected
 
     await awhile_asserts(has_backup)
+
+
+async def test_get_single_backup(master_controller, web_client):
+    controller = master_controller[0]
+
+    async def backup_list_not_none():
+        assert (await get_and_verify_json_body(web_client, "/backup"))["backups"] is not None
+
+    controller.start()
+    # Backups is empty list when backups have been listed but there are none
+    await awhile_asserts(backup_list_not_none)
+
+    def is_streaming_binlogs():
+        assert controller.backup_streams
+        assert controller.backup_streams[0].is_streaming_binlogs()
+
+    # Switching to active mode causes new backup to be created, which should be returned in listing soon
+    controller.switch_to_active_mode()
+    while_asserts(is_streaming_binlogs, timeout=15)
+
+    backup_stream_id = controller.state["backups"][0]["stream_id"]
+
+    async def has_single_backup_stream(stream_id):
+        url_encoded_id = parse.quote(stream_id)
+        await get_and_verify_json_body(web_client, f"/backup/{url_encoded_id}")
+
+    has_backup_stream = partial(has_single_backup_stream, backup_stream_id)
+
+    await awhile_asserts(has_backup_stream)
+
+
+async def test_get_missing_backup(master_controller, web_client):
+    controller = master_controller[0]
+
+    async def backup_list_not_none():
+        assert (await get_and_verify_json_body(web_client, "/backup"))["backups"] is not None
+
+    controller.start()
+    await awhile_asserts(backup_list_not_none)
+
+    await get_and_verify_json_body(web_client, "/backup/abc", expected_status=400)  # arguably this shoule be a 404
+
+
+async def test_delete_backup(master_controller, web_client):
+    controller = master_controller[0]
+
+    # Backup every 3 seconds
+    controller.backup_settings["backup_interval_minutes"] = 0.05
+    # Never delete backups if we don't have at least 2 no matter how old they are
+    controller.backup_settings["backup_count_min"] = 2
+    # Delete backups if there are more than this even if the backup to delete is newer than max age
+    # It's a rediculous high number to ensure we don't trigger the normal purge path as a just in case.
+    controller.backup_settings["backup_count_max"] = 10000
+    # Leave backup_age_days_max the default value, as we don't want the normal purge process to kick in.
+
+    async def backup_list_not_none():
+        assert (await get_and_verify_json_body(web_client, "/backup"))["backups"] is not None
+
+    controller.start()
+    await awhile_asserts(backup_list_not_none)
+
+    def is_streaming_binlogs():
+        assert controller.backup_streams
+        assert controller.backup_streams[0].is_streaming_binlogs()
+
+    # Switching to active mode causes new backup to be created, which should be returned in listing soon
+    controller.switch_to_active_mode()
+    while_asserts(is_streaming_binlogs, timeout=15)
+
+    # Create a second backup so we can delete the first.
+    # await post_and_verify_json_body(web_client, "/backup", {"backup_type": WebServer.BackupType.basebackup})
+
+    async def has_atlieast_three_backups():
+        response = await get_and_verify_json_body(web_client, "/backup")
+        assert response["backups"]
+        assert len(response["backups"]) >= 3
+
+    await awhile_asserts(has_atlieast_three_backups, timeout=15)
+
+    # At least one stream should be closed, find it
+    closed_stream_id: str | None = None
+    backup: Backup
+    for backup in controller.state["backups"]:
+        if backup["closed_at"]:
+            closed_stream_id = backup["stream_id"]
+            break
+    assert closed_stream_id is not None
+
+    response = await web_client.delete(f"/backup/{closed_stream_id}")
+    assert response.status == 202, f"{response.status} != 202"
+    assert backup["delete_requested_at"] is not None
+
+    # Wait for the backup to be deleted/purged
+    async def backup_stream_deleted(stream_id):
+        url_encoded_id = parse.quote(stream_id)
+        await get_and_verify_json_body(web_client, f"/backup/{url_encoded_id}", expected_status=400)
+
+    backup_deleted = partial(backup_stream_deleted, closed_stream_id)
+
+    await awhile_asserts(backup_deleted, timeout=30)
+
+    assert closed_stream_id not in controller.state["delete_requests"]
 
 
 async def test_replication_state_set(master_controller, web_client):


### PR DESCRIPTION
# About this change: What it does, why it matters

Currently backups are deleted only if they age out, or if there are too many. There are situations where backups are taken of corrupted data that need to be removed. The new /backups/{stream_id} endpoint supports the GET and DELETE verbs as a natural extension of the existing /backup collection endpoint. The backup still has to be closed before it can be deleted.

