### PR TITLE
Disable innodb_strict_mode when rebuilding tables

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -459,6 +459,8 @@ class RestoreCoordinator(threading.Thread):
                 cursor.execute("SET SESSION sql_mode = %s", (lenient_sql_mode,))
             self.log.info("Disabling requirement for primary keys during tables rebuild")
             cursor.execute("SET SESSION sql_require_primary_key = false")
+            self.log.info("Disabling innodb strict mode during tables rebuild")
+            cursor.execute("SET SESSION innodb_strict_mode = false")
             cursor.execute(
                 "SELECT TABLE_SCHEMA,TABLE_NAME,TABLE_ROWS,AVG_ROW_LENGTH"
                 " FROM INFORMATION_SCHEMA.TABLES WHERE ENGINE='InnoDB'"

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -53,6 +53,10 @@ def _restore_coordinator_sequence(
         cursor.execute("SET SESSION sql_mode = ''")
         cursor.execute("CREATE TABLE bad0 (id INTEGER, data TEXT)")
         cursor.execute("CREATE TABLE bad1 (id INTEGER, data DATETIME default '0000-00-00 00:00:00')")
+        # Tables with compact rows and a row length longer than 8126 bytes raise an error unless strict mode is disabled
+        cursor.execute("SET SESSION innodb_strict_mode = false")
+        columns = ", ".join([f"d{i} CHAR(255)" for i in range(40)])
+        cursor.execute(f"CREATE TABLE bad2 ({columns}) ROW_FORMAT=COMPACT")
         cursor.execute("COMMIT")
 
     private_key_pem, public_key_pem = generate_rsa_key_pair()


### PR DESCRIPTION
# About this change: What it does, why it matters

If the option was already disabled in the session that created the table, then we need to also disable it when rebuilding the table or the rebuild can fail with:

`Row size too large. The maximum row size for the used table type, not counting BLOBs, is 8126.`