### PR TITLE
Make use of ssl_require config in restore coordinator [BF-1965]

### DIFF
--- a/myhoard.json
+++ b/myhoard.json
@@ -39,8 +39,8 @@
             "host": "127.0.0.1",
             "password": "f@keP@ssw0rd",
             "port": 3306,
-            "user": "root",
-            "require_ssl": false
+            "require_ssl": false,
+            "user": "root"
         },
         "config_file_name": "/etc/my.cnf",
         "data_directory": "/var/lib/mysql",

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -1133,6 +1133,7 @@ class RestoreCoordinator(threading.Thread):
             host=self.mysql_client_params["host"],
             password=self.mysql_client_params["password"],
             port=self.mysql_client_params["port"],
+            require_ssl=self.mysql_client_params.get("require_ssl", False),
             user=self.mysql_client_params["user"],
             timeout=timeout,
         ) as cursor:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -180,6 +180,7 @@ FLUSH PRIVILEGES;
         "host": "127.0.0.1",
         "password": password,
         "port": config_options.port,
+        "require_ssl": False,
         "timeout": 10,
         "user": "root",
     }

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -273,6 +273,7 @@ def _restore_coordinator_sequence(
         "host": "127.0.0.1",
         "password": mysql_master.password,
         "port": mysql_empty.port,
+        "require_ssl": mysql_master.connect_options["require_ssl"],
         "user": mysql_master.user,
     }
     state_file_name = os.path.join(session_tmpdir().strpath, "restore_coordinator.json")
@@ -372,6 +373,7 @@ def test_empty_last_relay(running_state, session_tmpdir, mysql_master, mysql_emp
         "host": "127.0.0.1",
         "password": mysql_master.password,
         "port": mysql_empty.port,
+        "require_ssl": mysql_master.connect_options["require_ssl"],
         "user": mysql_master.user,
     }
     state_file_name = os.path.join(session_tmpdir().strpath, "restore_coordinator.json")


### PR DESCRIPTION
Ensure `require_ssl` config is passed down (from `Controller`) to `RestoreCoordinator`.

[BF-1965](https://aiven.atlassian.net/browse/BF-1965)

[BF-1965]: https://aiven.atlassian.net/browse/BF-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ