### PR TITLE
Only include `myhoard/` in package [BF-2051]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     name="myhoard",
     version=version_for_setup_py,
     zip_safe=False,
-    packages=find_packages(exclude=["test"]),
+    packages=find_packages(include=["myhoard"]),
     install_requires=[
         "cryptography",
         "PyMySQL",


### PR DESCRIPTION
When excluding `test`, it didn't exclude the children. Now, we only include the package we want.
This also gives better guarantees about not including non-test private packages.

[BF-2051]

[BF-2051]: https://aiven.atlassian.net/browse/BF-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ