### PR TITLE
Disable foreign keys checks when rebuilding tables [BF-2138]

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -466,6 +466,7 @@ class RestoreCoordinator(threading.Thread):
             cursor.execute("SET SESSION sql_require_primary_key = false")
             self.log.info("Disabling innodb strict mode during tables rebuild")
             cursor.execute("SET SESSION innodb_strict_mode = false")
+            cursor.execute("SET SESSION foreign_key_checks = 0")
             cursor.execute(
                 "SELECT TABLE_SCHEMA,TABLE_NAME,TABLE_ROWS,AVG_ROW_LENGTH"
                 " FROM INFORMATION_SCHEMA.TABLES WHERE ENGINE='InnoDB'"


### PR DESCRIPTION
It might happen that rebuilding will fail with foreign key constraint error, so we should disable it while rebuilding.

[BF-2138]

[BF-2138]: https://aiven.atlassian.net/browse/BF-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ