### PR TITLE
Skip rebuilding tables if we encounter duplicates

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -486,6 +486,14 @@ class RestoreCoordinator(threading.Thread):
                 )
                 try:
                     cursor.execute(f"ALTER TABLE {escaped_table_designator} FORCE")
+                except pymysql.err.IntegrityError as e:
+                    # ERROR 1026: Duplicate entry
+                    # This happens for tables that had temporary duplicate rows in different transactions, we can't rebuild
+                    # those at the moment.
+                    if e.args[0] == 1026:
+                        self.log.error("Could not rebuild %s, error: %s, skipping it", escaped_table_designator, str(e))
+                    else:
+                        raise
                 except pymysql.err.OperationalError as e:
                     # ERROR 1148: The used command is not allowed with this MySQL version
                     if e.args[0] == 1148:


### PR DESCRIPTION
From the MySQL documentation

https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-limitations.html

"It is possible to encounter a duplicate key entry error (ERROR 1062 (23000): Duplicate entry), even if the duplicate entry is only temporary and would be reverted by a later entry in the online log."