### PR TITLE
Support multithreading for percona xtrabackups

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,20 @@ recommended not to use `/tmp` for this because that is an in-memory file
 system on many distributions and the exact space requirements for this
 directory are not well defined.
 
+**xtrabackup.copy_threads**
+
+Number of worker threads created by XtraBackup for parallel copying data files when taking a backup. The default value is ``1``.
+
+Note: It is recommended to use more threads for copying than to compress or encrypt.
+
+**xtrabackup.compress_threads**
+
+Number of worker threads created by XtraBackup for parallel compression when taking a backup.  The default value is ``1``.
+
+**xtrabackup.encrypt_threads**
+
+Number of worker threads created by XtraBackup for parallel encryption when taking a backup. The default value is ``1``.
+
 # HTTP API
 
 MyHoard provides an HTTP API for managing the service. The various entry points

--- a/myhoard.json
+++ b/myhoard.json
@@ -65,5 +65,10 @@
         "sudo", "/usr/bin/myhoard_mysql_env_update", "--", "/etc/systemd/system/mysqld.environment", "MYSQLD_OPTS"
     ],
     "systemd_service": "mysql-server",
-    "temporary_directory": "/var/tmp/sample_temp_dir"
+    "temporary_directory": "/var/tmp/sample_temp_dir",
+    "xtrabackup": {
+        "copy_threads": 1,
+        "compress_threads": 1,
+        "encrypt_threads": 1
+    }
 }

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -47,6 +47,9 @@ class BasebackupOperation:
     def __init__(
         self,
         *,
+        copy_threads=1,
+        compress_threads=1,
+        encrypt_threads=1,
         encryption_algorithm,
         encryption_key,
         mysql_client_params,
@@ -60,10 +63,13 @@ class BasebackupOperation:
     ):
         self.abort_reason = None
         self.binlog_info = None
+        self.copy_threads = copy_threads
+        self.compress_threads = compress_threads
         self.current_file = None
         self.data_directory_filtered_size = None
         self.data_directory_size_end: Optional[int] = None
         self.data_directory_size_start: Optional[int] = None
+        self.encrypt_threads = encrypt_threads
         self.encryption_algorithm = encryption_algorithm
         self.encryption_key = encryption_key
         self.log = logging.getLogger(self.__class__.__name__)
@@ -119,11 +125,14 @@ class BasebackupOperation:
                     f"--defaults-file={mysql_config_file.name}",
                     "--backup",
                     "--compress",
+                    f"--compress-threads={self.compress_threads}",
                     "--encrypt",
                     self.encryption_algorithm,
+                    f"--encrypt-threads={self.encrypt_threads}",
                     "--encrypt-key-file",
                     encryption_key_file.name,
                     "--no-version-check",
+                    f"--parallel={self.copy_threads}",
                     "--stream",
                     "xbstream",
                     "--target-dir",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -382,6 +382,11 @@ def fixture_myhoard_config(default_backup_site, mysql_master, session_tmpdir):
         ],
         "systemd_service": None,
         "temporary_directory": temp_dir,
+        "xtrabackup": {
+            "copy_threads": 1,
+            "compress_threads": 1,
+            "encrypt_threads": 1,
+        },
     }
 
 


### PR DESCRIPTION
[BF-2176]

# About this change: What it does, why it matters

Percona suggests to use multithreads for speeding up base backup creation for big datasets. This might help in cases where the backup lock is held for a long time
