### PR TITLE
support backup preservation  [BF-2219]

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,43 @@ Response on success looks like this:
 }
 ```
 
+
+## PUT /backup/{stream_id}/preserve
+
+Create a request for updating the preservation status of a backup. Request body must be like this:
+
+```
+{
+  "preserve_until": "2023-09-01T00:00:0000",
+  "wait_for_applied_preservation": 3.0,
+}
+```
+
+**stream_id**
+
+Identifier of this backup.
+
+**preserve_until**
+
+Optional datetime value in ISO format for keeping the backup from being deleted.
+If a valid value is provided, the backup will be preserved until the specified datetime.
+If not provided or has a null value, the backup can be deleted due to old age.
+
+**wait_for_applied_preservation**
+
+Optional amount of time to the wait for the preservation request to be effectively executed. The
+operation will block for up to as many seconds as specified by this parameter.
+
+
+Response on success looks like this:
+
+```
+{
+  "success": true
+}
+```
+
+
 ## PUT /replication_state
 
 This call can be used to inform MyHoard of the executed GTIDs on other servers


### PR DESCRIPTION
# About this change: What it does, why it matters

Supports request for preserving/holding a backup till a particular date, this way we can guarantee that the backup is not deleted during a restoration request.

If the oldest backup is being preserved, myhoard will not purge any backup but will keep generating new backups. Purging is resumed till the preservation date is met.

## How to request a backup preservation?

For preserving a backup, a request to the HTTP API needs to be performed. For example:
```
PUT /backup/valid_stream_id_1234/preserve
{
    "preserve_until": "2023-09-12T13:30:00"
}
```

This will trigger the controller on fetching the respective backup stream and storing `preserved_info.json` on the object storage, it will contain the request  `preserve_until`. After storing the file, all backups metadata are immediately refreshed and myhoard considers updated `preserve_until` values before trying to purge old backups.

## How to cancel a backup preservation?
```
PUT /backup/valid_stream_id_1234/preserve
{
    "preserve_until": null,
}
```
This will trigger the controller on fetching the respective backup stream and storing `preserved_info.json` on the object storage, but will store an empty "preseve_until" value. 
