### PR TITLE
remove backup preservation after restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ Create a request for updating the preservation status of a backup. Request body 
 ```
 {
   "preserve_until": "2023-09-01T00:00:0000",
+  "remove_after_restore": true,
   "wait_for_applied_preservation": 3.0,
 }
 ```
@@ -565,6 +566,11 @@ Identifier of this backup.
 Optional datetime value in ISO format for keeping the backup from being deleted.
 If a valid value is provided, the backup will be preserved until the specified datetime.
 If not provided or has a null value, the backup can be deleted due to old age.
+
+
+**remove_after_restore**
+
+If true, preservation will be removed after the backup is restored.
 
 **wait_for_applied_preservation**
 

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -445,7 +445,7 @@ class BackupStream(threading.Thread):
         )
         self.wakeup_event.set()
 
-    def mark_preservation(self, preserve_until: Optional[datetime]) -> None:
+    def mark_preservation(self, preserve_until: Optional[datetime], remove_after_restore: bool = False) -> None:
         if preserve_until:
             self.log.info("Marking stream %s preservation to %s.", self.stream_id, preserve_until)
         else:
@@ -453,6 +453,9 @@ class BackupStream(threading.Thread):
 
         preserved_info = {
             "preserve_until": preserve_until.isoformat() if preserve_until else None,
+            "remove_after_restore": remove_after_restore
+            if preserve_until
+            else None,  # only set when preserve_until is provided
             "server_id": self.server_id,
         }
 

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1527,7 +1527,7 @@ def test_mark_backup_preservation(
     def backup_has_preservation(stream_id):
         for backup in m_controller.state["backups"]:
             if backup["stream_id"] == stream_id:
-                assert backup["preserve_until"] is not None
+                assert backup["preserve_info"] is not None
                 break
         else:
             assert False, f"Backup with stream id {stream_id} not found."
@@ -1602,7 +1602,7 @@ def test_unmark_backup_preservation(
     preserve_until = datetime.datetime(2023, 9, 10)
     stream_id_to_preserve = m_controller.state["backups"][0]["stream_id"]
     m_controller.mark_backup_preservation(stream_id=stream_id_to_preserve, preserve_until=preserve_until)
-    wait_for_condition(lambda: m_controller.state["backups"][0]["preserve_until"] is not None, timeout=10)
+    wait_for_condition(lambda: m_controller.state["backups"][0]["preserve_info"] is not None, timeout=10)
 
     time_machine.move_to(datetime.datetime(2023, 9, 7))
     wait_for_condition(lambda: len(m_controller.state["backups"]) == 2, timeout=20)
@@ -1817,7 +1817,7 @@ def test_purge_old_backups_exceeding_backup_age_days_max(
                 "closed_at": now - 3 * 60,
                 "completed_at": now - 5 * 60,
                 "broken_at": None,
-                "preserve_until": None,
+                "preserve_info": None,
                 "recovery_site": False,
                 "stream_id": stream_id,
                 "resumable": True,

--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -77,7 +77,7 @@ async def test_backup_list(master_controller, web_client):
             "broken_at",
             "closed_at",
             "completed_at",
-            "preserve_until",
+            "preserve_info",
             "recovery_site",
             "resumable",
             "site",


### PR DESCRIPTION
# About this change: What it does, why it matters
Remove preservation after the backup is restored. This will help avoiding preserving a backup for too long when it is just locked for restoring
