### PR TITLE
Read xtrabackup settings from config

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -157,6 +157,7 @@ class Controller(threading.Thread):
         stats,
         temp_dir,
         restore_free_memory_percentage=None,
+        xtrabackup_settings: Dict[str, int],
     ):
         super().__init__()
         self.log = logging.getLogger(self.__class__.__name__)
@@ -228,6 +229,7 @@ class Controller(threading.Thread):
         self.stats = stats
         self.temp_dir = temp_dir
         self.wakeup_event = threading.Event()
+        self.xtrabackup_settings = xtrabackup_settings
         self._get_upload_backup_site()
         self._update_mode_tag()
 
@@ -756,6 +758,7 @@ class Controller(threading.Thread):
             stats=self.stats,
             stream_id=stream_id,
             temp_dir=self.temp_dir,
+            xtrabackup_settings=self.xtrabackup_settings,
         )
 
     def _delete_backup_stream_state(self, stream_id):
@@ -1728,6 +1731,7 @@ class Controller(threading.Thread):
             stats=self.stats,
             stream_id=stream_id,
             temp_dir=self.temp_dir,
+            xtrabackup_settings=self.xtrabackup_settings,
         )
         self.backup_streams.append(stream)
         self.state_manager.update_state(

--- a/myhoard/myhoard.py
+++ b/myhoard/myhoard.py
@@ -2,7 +2,7 @@
 from myhoard import version
 from myhoard.controller import Controller
 from myhoard.statsd import StatsClient
-from myhoard.util import detect_running_process_id, wait_for_port
+from myhoard.util import DEFAULT_XTRABACKUP_SETTINGS, detect_running_process_id, wait_for_port
 from myhoard.web_server import WebServer
 
 import argparse
@@ -209,6 +209,7 @@ class MyHoard:
             state_dir=self.config["state_directory"],
             stats=statsd,
             temp_dir=self.config["temporary_directory"],
+            xtrabackup_settings=self.config.get("xtrabackup", DEFAULT_XTRABACKUP_SETTINGS),
         )
         self.controller.start()
         self.web_server = WebServer(

--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -32,6 +32,11 @@ ERR_TIMEOUT = 2013
 XTRABACKUP_VERSION_REGEX = re.compile(r"^xtrabackup version ([\d\.\-]).+")
 VERSION_SPLITTING_REGEX = re.compile(r"[\.-]")
 
+DEFAULT_XTRABACKUP_SETTINGS = {
+    "copy_threads": 1,
+    "compress_threads": 1,
+    "encrypt_threads": 1,
+}
 
 GtidRangeTuple = tuple[int, int, str, int, int]
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -102,6 +102,7 @@ def build_controller(
         state_dir=state_dir,
         stats=build_statsd_client(),
         temp_dir=temp_dir,
+        xtrabackup_settings=myhoard_util.DEFAULT_XTRABACKUP_SETTINGS,
     )
     return controller
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ from . import (
     random_basic_string,
 )
 from myhoard.controller import BackupSiteInfo, Controller
-from myhoard.util import atomic_create_file, change_master_to, mysql_cursor, wait_for_port
+from myhoard.util import atomic_create_file, change_master_to, DEFAULT_XTRABACKUP_SETTINGS, mysql_cursor, wait_for_port
 from myhoard.web_server import WebServer
 from py.path import local as LocalPath
 from typing import Callable, Iterator, Optional
@@ -382,11 +382,7 @@ def fixture_myhoard_config(default_backup_site, mysql_master, session_tmpdir):
         ],
         "systemd_service": None,
         "temporary_directory": temp_dir,
-        "xtrabackup": {
-            "copy_threads": 1,
-            "compress_threads": 1,
-            "encrypt_threads": 1,
-        },
+        "xtrabackup": DEFAULT_XTRABACKUP_SETTINGS,
     }
 
 


### PR DESCRIPTION
# About this change: What it does, why it matters

https://github.com/Aiven-Open/myhoard/commit/194c6c9051f452cc8e600f742490cbe0901551ec Supports xtrabackup multithreading parameters, but seems I missed passing the parameters from the config file to the BackupStream. These changes fix this.
