### PR TITLE
Make restore workers pool configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,11 @@ here.
 Boolean value. Enables a mechanism to automatically mark backups as broken if restoration fails for
 multiple times in a row. Defaults to `false`
 
+**restore_download_workers_count**
+
+Number of worker processes downloading binlogs during a restore,
+defaults to `max(cpu_count - 1, 1)`
+
 **restore_free_memory_percentage**
 
 Maximum percentage of system memory to allow xtrabackup to use while

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -165,6 +165,7 @@ class Controller(threading.Thread):
         state_dir,
         stats,
         temp_dir,
+        restore_download_workers_count: int,
         restore_free_memory_percentage=None,
         xtrabackup_settings: Dict[str, int],
         auto_mark_backups_broken: bool = False,
@@ -208,6 +209,7 @@ class Controller(threading.Thread):
         self.optimize_tables_before_backup = optimize_tables_before_backup
         self.restart_mysqld_callback = restart_mysqld_callback
         self.restore_max_binlog_bytes = restore_max_binlog_bytes
+        self.restore_download_workers_count = restore_download_workers_count
         self.restore_free_memory_percentage: Optional[int] = restore_free_memory_percentage
         self.restore_coordinator: Optional[RestoreCoordinator] = None
         self.seen_basebackup_infos: Dict[str, BaseBackup] = {}
@@ -895,6 +897,7 @@ class Controller(threading.Thread):
         # TODO site change triggers full backup
         self.restore_coordinator = RestoreCoordinator(
             binlog_streams=options["binlog_streams"],
+            download_workers_count=self.restore_download_workers_count,
             file_storage_config=storage_config,
             max_binlog_bytes=self.restore_max_binlog_bytes,
             free_memory_percentage=self.restore_free_memory_percentage,

--- a/myhoard/myhoard.py
+++ b/myhoard/myhoard.py
@@ -15,6 +15,7 @@ import argparse
 import asyncio
 import json
 import logging
+import multiprocessing
 import os
 import signal
 import subprocess
@@ -227,6 +228,9 @@ class MyHoard:
             tags=statsd_config["tags"],
         )
         mysql = self.config["mysql"]
+        restore_download_workers_count = self.config.get("restore_download_workers", None)
+        if restore_download_workers_count is None:
+            restore_download_workers_count = max(multiprocessing.cpu_count() - 1, 1)
         self.controller = Controller(
             backup_settings=self.config["backup_settings"],
             backup_sites=self.config["backup_sites"],
@@ -240,6 +244,7 @@ class MyHoard:
             optimize_tables_before_backup=self.config.get("optimize_tables_before_backup", False),
             restart_mysqld_callback=self._restart_mysqld,
             restore_max_binlog_bytes=self.config["restore_max_binlog_bytes"],
+            restore_download_workers_count=restore_download_workers_count,
             restore_free_memory_percentage=self.config.get("restore_free_memory_percentage"),
             server_id=self.config["server_id"],
             state_dir=self.config["state_directory"],

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -164,6 +164,7 @@ class RestoreCoordinator(threading.Thread):
         self,
         *,
         binlog_streams: List[BinlogStream],
+        download_workers_count: int,
         file_storage_config,
         free_memory_percentage,
         max_binlog_bytes=None,
@@ -195,6 +196,7 @@ class RestoreCoordinator(threading.Thread):
         # a basebackup fails for any reason but earlier backups are available and basebackup from one of those
         # can be successfully restored.
         self.binlog_streams = binlog_streams
+        self.download_workers_count = download_workers_count
         self.current_file = None
         self.file_storage_pool = TransferPool()
         self.file_storage_config = file_storage_config
@@ -1682,14 +1684,13 @@ class RestoreCoordinator(threading.Thread):
         return f"{local_name}.prefetch"
 
     def _start_process_pool(self) -> None:
-        process_count = max(multiprocessing.cpu_count() - 1, 1)
         config = {
             "object_storage": self.file_storage_config,
             "rsa_private_key_pem": self.rsa_private_key_pem.decode("ascii"),
         }
         self.worker_processes = [
             self.mp_context.Process(target=download_binlog, args=(config, self.queue_out, self.queue_in))
-            for _ in range(process_count)
+            for _ in range(self.download_workers_count)
         ]
         for worker in self.worker_processes:
             worker.start()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -118,6 +118,7 @@ def build_controller(
         mysql_relay_log_prefix=mysql_config.config_options.relay_log_file_prefix,
         restart_mysqld_callback=lambda **kwargs: restart_mysql(mysql_config, **kwargs),
         restore_max_binlog_bytes=2 * 1024 * 1024,
+        restore_download_workers_count=2,
         server_id=mysql_config.server_id,
         state_dir=state_dir,
         stats=build_statsd_client(),

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -306,6 +306,7 @@ def _restore_coordinator_sequence(
             {"site": "default", "stream_id": bs1.state["stream_id"]},
             {"site": "default", "stream_id": bs2.state["stream_id"]},
         ],
+        download_workers_count=2,
         file_storage_config={
             "directory": backup_target_location,
             "storage_type": "local",
@@ -418,6 +419,7 @@ def test_empty_last_relay(running_state, session_tmpdir, mysql_master, mysql_emp
         # We do not connect to the db in this call we just need a RestoreCoordinator object
         rc = RestoreCoordinator(
             binlog_streams=[],
+            download_workers_count=2,
             file_storage_config={},
             free_memory_percentage=80,
             mysql_client_params=restored_connect_options,
@@ -448,6 +450,7 @@ def test_empty_last_relay(running_state, session_tmpdir, mysql_master, mysql_emp
 def test_should_mark_backup_as_broken(session_tmpdir):
     rc = RestoreCoordinator(
         binlog_streams=[],
+        download_workers_count=2,
         file_storage_config={},
         free_memory_percentage=80,
         mysql_client_params="-",
@@ -487,6 +490,7 @@ def test_restore_coordinator_check_parameter_before_restart(session_tmpdir):
 
     rc = RestoreCoordinator(
         binlog_streams=[],
+        download_workers_count=2,
         file_storage_config={},
         free_memory_percentage=80,
         mysql_client_params={},
@@ -582,6 +586,7 @@ def test_basebackup_bytes_total(
 ) -> None:
     rc = RestoreCoordinator(
         binlog_streams=[],
+        download_workers_count=2,
         file_storage_config={},
         free_memory_percentage=80,
         mysql_client_params="-",


### PR DESCRIPTION
# About this change: What it does, why it matters

Starting as many Python interpreters as there are CPUs can be problematic, particularly when running tests using myhoard and when these tests are also parallelized.

