### PR TITLE
Restrict env update command to specific variable and values

### DIFF
--- a/myhoard.json
+++ b/myhoard.json
@@ -62,7 +62,7 @@
     },
     "systemctl_command": ["sudo", "/usr/bin/systemctl"],
     "systemd_env_update_command": [
-        "sudo", "/usr/bin/myhoard_mysql_env_update", "--", "/etc/systemd/system/mysqld.environment", "MYSQLD_OPTS"
+        "sudo", "/usr/bin/myhoard_mysql_env_update", "-f", "/etc/systemd/system/mysqld.environment"
     ],
     "systemd_service": "mysql-server",
     "temporary_directory": "/var/tmp/sample_temp_dir",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "paramiko",
     "PyMySQL >= 0.9.2",
     "PySocks",
+    # rohmu is incompatible with latest version snappy 0.7.1
+    "python-snappy == 0.6.1",
     "rohmu == 1.0.7",
     "sentry-sdk==1.14.0",
 ]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -376,9 +376,8 @@ def fixture_myhoard_config(default_backup_site, mysql_master, session_tmpdir):
         "systemd_env_update_command": [
             "sudo",
             "/usr/bin/myhoard_mysql_env_update",
-            "--",
+            "-f",
             "/etc/systemd/system/mysqld.environment",
-            "MYSQLD_OPTS",
         ],
         "systemd_service": None,
         "temporary_directory": temp_dir,


### PR DESCRIPTION
Restrict/simplify`myhoard_mysql_env_update` script can only update the `MYSQLD_OPTS` variable with specific values.