### PR TITLE
Do not purge read-only backups regardless of age

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -247,6 +247,7 @@ class Controller(threading.Thread):
         with self.lock:
             for stream in self.backup_streams:
                 if stream.active_phase == BackupStream.ActivePhase.basebackup:
+                    self.log.info("Not safe to reload while taking basebackup")
                     return False
         return True
 
@@ -1293,7 +1294,7 @@ class Controller(threading.Thread):
                 stream.remove_binlogs(binlogs)
 
     def _purge_old_backups(self):
-        purgeable = [backup for backup in self.state["backups"] if backup["completed_at"]]
+        purgeable = [backup for backup in self.state["backups"] if backup["completed_at"] and not backup["recovery_site"]]
         broken_backups_count = sum(backup["broken_at"] is not None for backup in purgeable)
         # do not consider broken backups for the count, they will still be purged
         # but we should only purge when the count of non-broken backups has exceeded the limit.


### PR DESCRIPTION
After MyHoard restore from a backup, `myhoard` might have not reloaded latest configuration yet, the backup list may still have `read_only` backups from recovery site. 

MyHoard should not touch those backups even though they are in the backup list.
