### PR TITLE
Support `--register-redo-log-consumer` param for xtrabackup

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,11 +430,19 @@ Note: It is recommended to use more threads for copying than to compress or encr
 
 **xtrabackup.compress_threads**
 
-Number of worker threads created by XtraBackup for parallel compression when taking a backup.  The default value is ``1``.
+Number of worker threads created by XtraBackup for parallel compression when taking a backup. The default value is ``1``.
 
 **xtrabackup.encrypt_threads**
 
 Number of worker threads created by XtraBackup for parallel encryption when taking a backup. The default value is ``1``.
+
+**xtrabackup.register_redo_log_consumer**
+
+Lets XtraBackup register as a redo log consumer at the start of the backup.
+The server does not remove a redo log that Percona XtraBackup (the consumer) has not yet copied.
+The consumer reads the redo log and manually advances the log sequence number (LSN).
+The server blocks the writes during the process. Based on the redo log consumption,
+the server determines when it can purge the log. It is disabled by default.
 
 # HTTP API
 

--- a/myhoard.json
+++ b/myhoard.json
@@ -69,6 +69,7 @@
     "xtrabackup": {
         "copy_threads": 1,
         "compress_threads": 1,
-        "encrypt_threads": 1
+        "encrypt_threads": 1,
+        "register_redo_log_consumer": false
     }
 }

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -1008,11 +1008,12 @@ class BackupStream(threading.Thread):
             mysql_client_params=self.mysql_client_params,
             mysql_config_file_name=self.mysql_config_file_name,
             mysql_data_directory=self.mysql_data_directory,
+            optimize_tables_before_backup=self.optimize_tables_before_backup,
             progress_callback=self._basebackup_progress_callback,
+            register_redo_log_consumer=self.xtrabackup_settings["register_redo_log_consumer"],
             stats=self.stats,
             stream_handler=self._basebackup_stream_handler,
             temp_dir=self.temp_dir,
-            optimize_tables_before_backup=self.optimize_tables_before_backup,
         )
         try:
             self.basebackup_operation.create_backup()

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -57,6 +57,7 @@ class BasebackupOperation:
         mysql_data_directory,
         optimize_tables_before_backup=False,
         progress_callback=None,
+        register_redo_log_consumer=False,
         stats,
         stream_handler,
         temp_dir,
@@ -85,6 +86,7 @@ class BasebackupOperation:
         self.proc = None
         self.processed_original_bytes = 0
         self.progress_callback = progress_callback
+        self.register_redo_log_consumer = register_redo_log_consumer
         self.stats = stats
         self.stream_handler = stream_handler
         self.temp_dir: Optional[str] = None
@@ -140,6 +142,9 @@ class BasebackupOperation:
                     "--extra-lsndir",
                     self.lsn_dir,
                 ]
+
+                if self.register_redo_log_consumer:
+                    command_line.append("--register-redo-log-consumer")
 
                 with self.stats.timing_manager("myhoard.basebackup.xtrabackup_backup"):
                     with subprocess.Popen(

--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -36,6 +36,7 @@ DEFAULT_XTRABACKUP_SETTINGS = {
     "copy_threads": 1,
     "compress_threads": 1,
     "encrypt_threads": 1,
+    "register_redo_log_consumer": False,
 }
 
 GtidRangeTuple = tuple[int, int, str, int, int]


### PR DESCRIPTION
# About this change: What it does, why it matters

This adds support for `--register-redo-log-consumer` param, which when set, lets XtraBackup register as a redo log consumer so that the server does not remove redo logs that are not yet copied by the backup process.

https://docs.percona.com/percona-xtrabackup/8.0/xtrabackup-option-reference.html#register-redo-log-consumer
