### PR TITLE
Optimize binlog_upload_delay function

### DIFF
--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -353,16 +353,17 @@ class BackupStream(threading.Thread):
 
     @property
     def binlog_upload_delay(self) -> int:
-        """Returns the number of seconds since the oldest pending binlog was written."""
+        """Returns the number of seconds since the oldest pending binlog was written.
+        Only stats the first existing pending binlog since the list is ordered by index."""
         now = time.time()
-        oldest_mtime = now
         for binlog in self.state["pending_binlogs"]:
             try:
-                oldest_mtime = min(oldest_mtime, os.stat(binlog["full_name"]).st_mtime)
+                oldest_mtime = os.stat(binlog["full_name"]).st_mtime
+                return int(now - oldest_mtime)
             except FileNotFoundError:
-                pass  # binlog was just purged, so ignore it.
-
-        return int(now - oldest_mtime)
+                # binlog was just purged, so skip it.
+                continue
+        return 0
 
     @property
     def created_at(self) -> float:


### PR DESCRIPTION
This function used to call stat on every single pending binlog just to return an upload delay, which is wasteful and in case of huge pile of binlogs it's a significant performance dip. Instead we find the first non purged binlog and use stat of this file, as it's guaranteed to be the oldest one.

# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)
