### PR TITLE
Fix relay log position correction for backup restoration

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -1348,7 +1348,7 @@ class RestoreCoordinator(threading.Thread):
         local_name = self._relay_log_name(index=binlog["adjusted_remote_index"] + self.state["binlog_name_offset"])
         gtid_infos = []
         found_last_entry = False
-        for gtid_info in read_gtids_from_log(local_name, read_until_position=binlog_position):
+        for gtid_info in read_gtids_from_log(local_name):
             _timestamp, _server_id, uuid_str, gno, start_position = gtid_info
             last_gno = last_gnos.get(uuid_str)
             if last_gno == gno:
@@ -1363,6 +1363,9 @@ class RestoreCoordinator(threading.Thread):
                         gno,
                     )
                     self.update_state(binlog_position=start_position)
+                break
+            # Stop if we've passed the reported position without finding the matching GTID
+            if not found_last_entry and start_position >= binlog_position:
                 break
             gtid_infos.append(gtid_info)
         return list(build_gtid_ranges(gtid_infos))


### PR DESCRIPTION
`_parse_gtid_executed_ranges()` uses `read_until_position=binlog_position` when scanning the binlog file for GTID events.
If `xtrabackup` reports a position that's mid-event (due to a race in performance_schema.log_status — MySQL Bug#32442772 https://github.com/mysql/mysql-server/commit/749fd742b1c83d38590afb1364fd40fd3edfcb66), the existing position-correction code can't find the next valid event boundary because reading stops too early.
This causes `CHANGE REPLICATION SOURCE TO RELAY_LOG_POS=<mid-event>` which fails with error 13121 (relay log read failure).

Remove `read_until_position` to allow scanning past the reported position, with a safety bound to prevent reading the entire file when the matching GTID isn't found.

It seems it was fixed in MySQL 8.0.42 https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-42.html