### PR TITLE
Allow updating binlog purge settings while taking the backup

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -262,6 +262,10 @@ class Controller(threading.Thread):
                     return False
         return True
 
+    def update_binlog_purge_settings(self, binlog_purge_settings) -> None:
+        self.log.info("Updating binlog purge settings to %r", binlog_purge_settings)
+        self.binlog_purge_settings = binlog_purge_settings
+
     def mark_backup_requested(
         self,
         *,

--- a/myhoard/myhoard.py
+++ b/myhoard/myhoard.py
@@ -54,6 +54,7 @@ class MyHoard:
     async def _reload_and_initialize_if_possible(self):
         if self.controller and not self.controller.is_safe_to_reload():
             self.log.info("Reload requested but controller state does not allow safe reload, postponing")
+            self._apply_safe_config_updates()
             await asyncio.sleep(self.reload_retry_interval)
             asyncio.ensure_future(self._reload_and_initialize_if_possible())
             return
@@ -86,6 +87,22 @@ class MyHoard:
         self.log.info("Exiting")
 
         return 0
+
+    def _apply_safe_config_updates(self):
+        """Apply config changes that are safe to update without a full reload.
+
+        This is called when a full reload is not possible (e.g. during basebackup)
+        to ensure settings like binlog purge/retention are applied promptly.
+        """
+        try:
+            with open(self.config_file, "r") as f:
+                new_config = json.load(f)
+            new_purge_settings = new_config.get("binlog_purge_settings")
+            if new_purge_settings and new_purge_settings != self.config.get("binlog_purge_settings"):
+                self.controller.update_binlog_purge_settings(new_purge_settings)
+                self.config["binlog_purge_settings"] = new_purge_settings
+        except (OSError, ValueError) as ex:
+            self.log.warning("Failed to apply safe config updates: %r", ex)
 
     def _load_configuration(self):
         with open(self.config_file, "r") as f:

--- a/test/test_myhoard.py
+++ b/test/test_myhoard.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
 from . import get_random_port, wait_for_port, while_asserts
+from myhoard.myhoard import MyHoard
 from unittest.mock import MagicMock, patch
 
 import contextlib
 import json
+import logging
 import os
 import pytest
 import requests
@@ -228,3 +230,66 @@ def test_main_logging_respects_log_level_argument(
 
         call_kwargs = mock_basic_config.call_args[1]
         assert call_kwargs["level"] == log_level
+
+
+class TestApplySafeConfigUpdates:
+    def test_updates_binlog_purge_settings_when_changed(self, tmp_path):
+        original_settings = {
+            "enabled": True,
+            "min_binlog_age_before_purge": 600,
+            "purge_interval": 60,
+            "purge_when_observe_no_streams": True,
+        }
+        new_settings = {
+            "enabled": True,
+            "min_binlog_age_before_purge": 3600,
+            "purge_interval": 60,
+            "purge_when_observe_no_streams": True,
+        }
+
+        config_file = tmp_path / "myhoard.json"
+        config_file.write_text(json.dumps({"binlog_purge_settings": new_settings}))
+
+        hoard = MyHoard.__new__(MyHoard)
+        hoard.log = logging.getLogger("test")
+        hoard.config_file = str(config_file)
+        hoard.config = {"binlog_purge_settings": original_settings}
+        hoard.controller = MagicMock()
+
+        hoard._apply_safe_config_updates()  # pylint: disable=protected-access
+
+        hoard.controller.update_binlog_purge_settings.assert_called_once_with(new_settings)
+        assert hoard.config["binlog_purge_settings"] == new_settings
+
+    def test_skips_update_when_settings_unchanged(self, tmp_path):
+        settings = {
+            "enabled": True,
+            "min_binlog_age_before_purge": 600,
+            "purge_interval": 60,
+            "purge_when_observe_no_streams": True,
+        }
+
+        config_file = tmp_path / "myhoard.json"
+        config_file.write_text(json.dumps({"binlog_purge_settings": settings}))
+
+        hoard = MyHoard.__new__(MyHoard)
+        hoard.log = logging.getLogger("test")
+        hoard.config_file = str(config_file)
+        hoard.config = {"binlog_purge_settings": settings}
+        hoard.controller = MagicMock()
+
+        hoard._apply_safe_config_updates()  # pylint: disable=protected-access
+
+        hoard.controller.update_binlog_purge_settings.assert_not_called()
+
+    def test_handles_missing_config_file_gracefully(self, tmp_path):
+        hoard = MyHoard.__new__(MyHoard)
+        hoard.log = logging.getLogger("test")
+        hoard.config_file = str(tmp_path / "nonexistent.json")
+        hoard.config = {"binlog_purge_settings": {}}
+        hoard.controller = MagicMock()
+
+        # Should not raise
+        hoard._apply_safe_config_updates()  # pylint: disable=protected-access
+
+        hoard.controller.update_binlog_purge_settings.assert_not_called()


### PR DESCRIPTION
When a user changes `binlog_retention_period` while a basebackup is in progress, the new setting is not applied until the backup completes (potentially hours later). This is because myhoard's SIGHUP reload does a full stop/start cycle, which is blocked by `is_safe_to_reload()` during basebackup.
This allows safe settings (`binlog_retention_period`) to be applied when reloading is not considered safe.

# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)
