### PR TITLE
Uploading binlogs in batches

### DIFF
--- a/myhoard/binlog_scanner.py
+++ b/myhoard/binlog_scanner.py
@@ -9,6 +9,8 @@ import os
 import threading
 import time
 
+BINLOG_UPLOAD_BATCH_SIZE = 10
+
 
 class BinlogInfo(TypedDict):
     file_name: str
@@ -68,7 +70,7 @@ class BinlogScanner:
         last_processed_at = time.time()
 
         next_index: int = self.state["next_index"]
-        while True:
+        for _ in range(BINLOG_UPLOAD_BATCH_SIZE):
             # We only scan completed files so expect the index following our next
             # index to be present as well
             if not os.path.exists(self.build_full_name(next_index + 1)):


### PR DESCRIPTION
BinlogScanner.scan_new() processes all pending binlogs in a single loop before invoking the callback that delivers them to BackupStream via add_binlogs(). With a large backlog, the backup stream sits idle in binlog_catchup phase with an empty pending_binlogs list, unable to upload anything until the entire scan completes.