### PR TITLE
Add preparing_backup restore phase with LSN-derived progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ status 400. For successful requests the response body looks like this:
 {
   "basebackup_compressed_bytes_downloaded": 8489392354,
   "basebackup_compressed_bytes_total": 37458729461,
+  "basebackup_prepare_progress": null,
   "binlogs_being_restored": 0,
   "binlogs_pending": 73,
   "binlogs_restored": 0,
@@ -807,6 +808,16 @@ also been processed.
 **basebackup_compressed_bytes_total**
 
 Total number of (compressed) bytes in the full snapshot.
+
+**basebackup_prepare_progress**
+
+Progress of the current `xtrabackup --prepare` call as an integer
+percentage in the range 0..100, or `null` when the coordinator is
+outside `preparing_backup` or no scan line has been observed yet. The
+value is derived from the InnoDB "Doing recovery: scanned up to log
+sequence number N" lines and the `last_lsn` bound recorded in the
+backup's checkpoints file. On incremental restores this field tracks
+the current prepare iteration only and resets between required backups.
 
 **binlogs_being_restored**
 
@@ -832,7 +843,13 @@ Current phase of backup restoration. Possible options are these:
 - initiating_binlog_downloads: Binary log prefetch operations are being
   scheduled so that progress with those can be made while the full snapshot is
   being restored.
-- restoring_basebackup: The full snapshot is being downloaded and prepared.
+- restoring_basebackup: The full snapshot is being downloaded and
+  extracted (decompressed and decrypted via `xbstream`).
+- preparing_backup: `xtrabackup --prepare` is applying the redo/undo
+  logs captured in the basebackup, followed by a short `--move-back`.
+  On multi-TB restores the prepare step can take hours;
+  `basebackup_prepare_progress` reports LSN-derived progress while
+  `--prepare` is running and pins at 100 during `--move-back`.
 - rebuilding_tables: Rebuilding tables before restoring binary logs. This can
   avoid data corruption when updating from older MySQL versions.
 - refreshing_binlogs: Refreshing binary log info to see if new binary logs have

--- a/myhoard/basebackup_restore_operation.py
+++ b/myhoard/basebackup_restore_operation.py
@@ -5,10 +5,11 @@ from .util import (
     find_extra_xtrabackup_executables,
     get_xtrabackup_version,
     parse_version,
+    parse_xtrabackup_info,
 )
 from contextlib import suppress
 from rohmu.util import increase_pipe_capacity, set_stream_nonblocking
-from typing import Dict, Final, Optional
+from typing import Callable, Dict, Final, Optional
 
 import base64
 import fnmatch
@@ -33,6 +34,11 @@ class BasebackupRestoreOperation:
 
     prepare_completed_re = re.compile(r"Shutdown completed; log sequence number (\d+)$")
 
+    # Canonical InnoDB scan line, emitted repeatedly during recovery; its LSN
+    # monotonically advances towards last_lsn and is the only signal we use for
+    # prepare progress.
+    prepare_lsn_re = re.compile(r"Doing recovery: scanned up to log sequence number (\d+)")
+
     def __init__(
         self,
         *,
@@ -46,6 +52,7 @@ class BasebackupRestoreOperation:
         target_dir: str,
         temp_dir: str,
         backup_tool_version: str | None = None,
+        prepare_progress_callback: Optional[Callable[..., None]] = None,
     ):
         self.current_file = None
         self.data_directory_size_end = None
@@ -57,7 +64,7 @@ class BasebackupRestoreOperation:
         self.mysql_config_file_name = mysql_config_file_name
         self.mysql_data_directory = mysql_data_directory
         self.number_of_files = 0
-        self.prepared_lsn = None
+        self.prepared_lsn: Optional[int] = None
         self.proc: subprocess.Popen[bytes] | None = None
         self.stats = stats
         self.stream_handler = stream_handler
@@ -65,11 +72,35 @@ class BasebackupRestoreOperation:
         self.temp_dir = temp_dir
         self.backup_xtrabackup_info: Dict[str, str] | None = None
         self.backup_tool_version = backup_tool_version
+        # LSN bounds for prepare progress. Use last_lsn (redo stop LSN) over
+        # to_lsn so the bar doesn't hit 100% before the redo tail is applied,
+        # and scan_start (first observed scan-line LSN) over from_lsn so the
+        # bar doesn't sit at ~99% on full backups (from_lsn=0 there).
+        self._prepare_last_lsn: Optional[int] = None
+        self._prepare_scan_start_lsn: Optional[int] = None
+        self._prepare_current_lsn: Optional[int] = None
+        # Dedupe the callback: scan lines advance the LSN much more often than
+        # the truncated integer pct.
+        self._last_emitted_prepare_pct: Optional[int] = None
+        # Called synchronously from the coordinator thread (_process_output_loop
+        # drains stdout/stderr in-line); long callbacks stall the parser.
+        self._prepare_progress_callback = prepare_progress_callback
 
     def prepare_backup(
         self, incremental: bool = False, apply_log_only: bool = False, checkpoints_file_content: str | None = None
     ):
         # Write encryption key to file to avoid having it on command line. NamedTemporaryFile has mode 0600
+
+        # Reset progress state so values don't leak across prepare calls (e.g.
+        # required-backup iteration). Legacy backups without checkpoints
+        # content leave _prepare_last_lsn unset, which suppresses the parser.
+        self._prepare_last_lsn = None
+        self._prepare_scan_start_lsn = None
+        self._prepare_current_lsn = None
+        self._last_emitted_prepare_pct = None
+        if checkpoints_file_content:
+            checkpoints = parse_xtrabackup_info(checkpoints_file_content)
+            self._prepare_last_lsn = int(checkpoints["last_lsn"])
 
         incremental_dir = None
         try:
@@ -139,6 +170,7 @@ class BasebackupRestoreOperation:
                 # --use-free-memory-pct introduced in 8.0.30, but it doesn't work in 8.0.30 and leads to PBX crash
                 if self.free_memory_percentage is not None and get_xtrabackup_version() >= (8, 0, 32):
                     command_line.insert(2, f"--use-free-memory-pct={self.free_memory_percentage}")
+                self._set_prepare_current_lsn(None)
                 with self.stats.timing_manager("myhoard.basebackup_restore.xtrabackup_prepare"):
                     with subprocess.Popen(
                         command_line, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -336,6 +368,20 @@ class BasebackupRestoreOperation:
 
         self.log.info("xtrabackup-move: %r", line)
 
+    @property
+    def prepare_progress_pct(self) -> Optional[int]:
+        """xtrabackup --prepare progress as a 0..100 int, derived on demand.
+
+        None when last_lsn isn't known (legacy backup) or before the first scan
+        line has been seen.
+        """
+        if self._prepare_last_lsn is None or self._prepare_scan_start_lsn is None or self._prepare_current_lsn is None:
+            return None
+        span = self._prepare_last_lsn - self._prepare_scan_start_lsn
+        if span <= 0:
+            return 100
+        return max(0, min(100, int((self._prepare_current_lsn - self._prepare_scan_start_lsn) * 100.0 / span)))
+
     def _process_prepare_output_line(self, line: str, _stream_name: str) -> None:
         line = self.decode_output_line(line)
         if not line:
@@ -343,15 +389,69 @@ class BasebackupRestoreOperation:
 
         self._raise_if_no_space_left(line, "xtrabackup-prepare")
 
-        if not self._process_prepare_completed_line(line):
-            self.log.info("xtrabackup-prepare: %r", line)
+        # The shutdown line pins the bar at 100 even when intermediate scan
+        # lines didn't reach last_lsn (tiny redo log, already-prepared backup,
+        # int truncation). prepared_lsn typically equals or slightly exceeds
+        # _prepare_last_lsn; the property's min(100, ...) clamp handles the
+        # excess, and the span<=0 branch handles the no-scan-line case where
+        # scan_start gets seeded to prepared_lsn.
+        if (lsn := self._process_prepare_completed_line(line)) is not None:
+            self._set_prepare_current_lsn(lsn)
+            return
 
-    def _process_prepare_completed_line(self, line):
+        self.log.info("xtrabackup-prepare: %r", line)
+        if (lsn := self._advance_prepare_lsn(line)) is not None:
+            self._set_prepare_current_lsn(lsn)
+
+    def _emit_prepare_progress(self) -> None:
+        """Fire the callback iff the integer pct differs from the last emission."""
+        if self._prepare_progress_callback is None:
+            return
+        pct = self.prepare_progress_pct
+        if pct == self._last_emitted_prepare_pct:
+            return
+        self._last_emitted_prepare_pct = pct
+        self._prepare_progress_callback(pct=pct)
+        if pct is not None:
+            self.stats.gauge_int("myhoard.basebackup_restore.xtrabackup_prepare_progress", pct)
+
+    def _process_prepare_completed_line(self, line: str) -> Optional[int]:
+        """Return the LSN from the shutdown line and record prepared_lsn, else None."""
         match = self.prepare_completed_re.search(line)
-        if match:
-            self.prepared_lsn = int(match.group(1))
-            self.log.info("Restored backup prepared, lsn %s", self.prepared_lsn)
-        return match
+        if not match:
+            return None
+        self.prepared_lsn = int(match.group(1))
+        self.log.info("Restored backup prepared, lsn %s", self.prepared_lsn)
+        return self.prepared_lsn
+
+    def _advance_prepare_lsn(self, line: str) -> Optional[int]:
+        """Return the LSN parsed from a scan line, or None if no match or
+        last_lsn isn't known."""
+        if self._prepare_last_lsn is None:
+            return None
+        match = self.prepare_lsn_re.search(line)
+        if not match:
+            return None
+        return int(match.group(1))
+
+    def _set_prepare_current_lsn(self, lsn: Optional[int]) -> None:
+        """Update _prepare_current_lsn and fire the progress callback.
+
+        lsn=None is the "prepare is starting" edge: fires the callback once
+        with pct=None (coordinator uses this to flip into preparing_backup)
+        and skips the LSN/gauge bookkeeping entirely. LSN values that don't
+        advance _prepare_current_lsn are silently ignored.
+        """
+        if lsn is None:
+            if self._prepare_progress_callback is not None:
+                self._prepare_progress_callback(pct=None)
+            return
+        if self._prepare_current_lsn is not None and lsn <= self._prepare_current_lsn:
+            return
+        self._prepare_current_lsn = lsn
+        if self._prepare_scan_start_lsn is None:
+            self._prepare_scan_start_lsn = lsn
+        self._emit_prepare_progress()
 
     def _process_xbstream_output_line(self, line: str, _stream_name: str) -> None:
         line = self.decode_output_line(line)

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -257,7 +257,14 @@ class Controller(threading.Thread):
 
     def is_safe_to_reload(self) -> bool:
         restore_coordinator = self.restore_coordinator
-        if restore_coordinator and restore_coordinator.phase == RestoreCoordinator.Phase.restoring_basebackup:
+        # Neither phase is independently resumable: a reload-triggered restart
+        # rewinds to restoring_basebackup and re-runs the whole sequence,
+        # which can be hours on multi-TB restores.
+        unsafe_restore_phases = {
+            RestoreCoordinator.Phase.restoring_basebackup,
+            RestoreCoordinator.Phase.preparing_backup,
+        }
+        if restore_coordinator and restore_coordinator.phase in unsafe_restore_phases:
             return False
         with self.lock:
             for stream in self.backup_streams:

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -107,6 +107,12 @@ class RestoreCoordinator(threading.Thread):
         getting_backup_info = "getting_backup_info"
         initiating_binlog_downloads = "initiating_binlog_downloads"
         restoring_basebackup = "restoring_basebackup"
+        # Reached once xbstream extract is done and xtrabackup --prepare /
+        # --move-back is running. Distinct from restoring_basebackup so
+        # /status/restore can surface its own progress (multi-TB prepares can
+        # take hours). Not independently resumable: a resume re-enters
+        # restore_basebackup() and re-runs extract + prepare + move-back.
+        preparing_backup = "preparing_backup"
         rebuilding_tables = "rebuilding_tables"
         refreshing_binlogs = "refreshing_binlogs"
         applying_binlogs = "applying_binlogs"
@@ -157,6 +163,11 @@ class RestoreCoordinator(threading.Thread):
         target_time_reached: bool
         write_relay_log_manually: bool
         backup_xtrabackup_version: BinVersion | None
+        # 0..100 integer percent for the *current* xtrabackup --prepare call;
+        # reset between prepare calls in an incremental restore. Stored value
+        # may be stale outside Phase.preparing_backup (failure paths don't
+        # clear it); the API surface gates on the live phase.
+        basebackup_prepare_progress: Optional[int]
 
     POLL_PHASES = {Phase.waiting_for_apply_to_finish}
 
@@ -275,6 +286,7 @@ class RestoreCoordinator(threading.Thread):
             "target_time_reached": False,
             "write_relay_log_manually": False,
             "backup_xtrabackup_version": None,
+            "basebackup_prepare_progress": None,
         }
         self.state_manager = state_manager_class(lock=self.lock, state=self.state, state_file=state_file)
         self.stats = stats
@@ -366,7 +378,9 @@ class RestoreCoordinator(threading.Thread):
                     self.get_backup_info()
                 if self.phase == self.Phase.initiating_binlog_downloads:
                     self.initiate_binlog_downloads()
-                if self.phase == self.Phase.restoring_basebackup:
+                if self.phase in {self.Phase.restoring_basebackup, self.Phase.preparing_backup}:
+                    # preparing_backup isn't independently resumable; on resume
+                    # we re-run extract + prepare + move-back from scratch.
                     self.restore_basebackup()
                 if self.phase == self.Phase.rebuilding_tables:
                     self.rebuild_tables()
@@ -473,6 +487,13 @@ class RestoreCoordinator(threading.Thread):
         apply_log_only: bool = False,
         incremental: bool = False,
     ) -> None:
+        # Reset state left over from a previous required-backup iteration so
+        # /status/restore reflects the upcoming xbstream extract, not the prior
+        # prepare.
+        self.update_state(
+            phase=self.Phase.restoring_basebackup,
+            basebackup_prepare_progress=None,
+        )
         encryption_key = rsa_decrypt_bytes(self.rsa_private_key_pem, bytes.fromhex(backup_info["encryption_key"]))
         self.basebackup_restore_operation = BasebackupRestoreOperation(
             encryption_algorithm="AES256",
@@ -485,6 +506,7 @@ class RestoreCoordinator(threading.Thread):
             temp_dir=temp_dir,
             free_memory_percentage=self.free_memory_percentage,
             backup_tool_version=backup_info.get("tool_version"),
+            prepare_progress_callback=self._on_prepare_progress,
         )
         try:
             self.basebackup_restore_operation.prepare_backup(
@@ -498,6 +520,14 @@ class RestoreCoordinator(threading.Thread):
             self.stats.increase("myhoard.disk_full_errors")
             self.update_state(phase=self.Phase.failed)
             raise
+
+    def _on_prepare_progress(self, *, pct: int | None) -> None:
+        # pct=None is the "prepare starting" edge; subsequent calls carry the
+        # latest integer pct from the xtrabackup output parser.
+        self.update_state(
+            phase=self.Phase.preparing_backup,
+            basebackup_prepare_progress=pct,
+        )
 
     def restore_basebackup(self) -> None:
         if os.path.exists(self.mysql_data_directory):
@@ -569,6 +599,7 @@ class RestoreCoordinator(threading.Thread):
                     phase=next_phase,
                     basebackup_restore_duration=duration,
                     last_rebuilt_table=None,
+                    basebackup_prepare_progress=None,
                 )
 
             except Exception as ex:  # pylint: disable=broad-except

--- a/myhoard/web_server.py
+++ b/myhoard/web_server.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from myhoard.backup_stream import BackupStream
 from myhoard.controller import Controller
 from myhoard.errors import BadRequest
+from myhoard.restore_coordinator import RestoreCoordinator
 from typing import Any
 
 import asyncio
@@ -205,6 +206,14 @@ class WebServer:
                 raise Exception("Restore coordinator is not available even though state is 'restore'")
 
             with coordinator.state_manager.lock:
+                # Gate the stored pct on the live phase: failure paths
+                # (Phase.failed, Phase.failed_basebackup) don't clear it, so
+                # exposing it unconditionally would leak a stale value.
+                prepare_progress = (
+                    coordinator.state.get("basebackup_prepare_progress")
+                    if coordinator.phase == RestoreCoordinator.Phase.preparing_backup
+                    else None
+                )
                 response = {
                     "basebackup_compressed_bytes_downloaded": coordinator.basebackup_bytes_downloaded,
                     "basebackup_compressed_bytes_total": coordinator.basebackup_bytes_total,
@@ -212,6 +221,7 @@ class WebServer:
                     "binlogs_pending": coordinator.binlogs_pending,
                     "binlogs_restored": coordinator.binlogs_restored,
                     "phase": coordinator.phase,
+                    "basebackup_prepare_progress": prepare_progress,
                 }
             return json_response(response)
 

--- a/test/test_basebackup_restore_operation.py
+++ b/test/test_basebackup_restore_operation.py
@@ -15,6 +15,142 @@ import tempfile
 pytestmark = [pytest.mark.unittest, pytest.mark.all]
 
 
+def _make_restore_op(prepare_progress_callback=None):
+    """Minimal BasebackupRestoreOperation for parser unit tests; no subprocess
+    is launched."""
+    return BasebackupRestoreOperation(
+        encryption_algorithm="AES256",
+        encryption_key=b"0" * 24,
+        free_memory_percentage=80,
+        mysql_config_file_name="/dev/null",
+        mysql_data_directory="/dev/null",
+        stats=build_statsd_client(),
+        stream_handler=None,
+        target_dir="",
+        temp_dir="",
+        prepare_progress_callback=prepare_progress_callback,
+    )
+
+
+class TestPrepareOutputParser:
+    """The parser only drives progress from the canonical InnoDB scan line:
+
+        InnoDB: Doing recovery: scanned up to log sequence number N
+
+    Other lines mentioning LSNs are intentionally ignored.
+    """
+
+    # pylint: disable=protected-access
+    def _feed(self, op, lines):
+        for line in lines:
+            op._process_prepare_output_line(line.encode("utf-8"), "stderr")
+
+    def test_lsn_progress_monotone(self):
+        # The first scan line seeds scan_start_lsn (so the window anchors at
+        # the first observed LSN, not from_lsn=0); later lines animate across
+        # (last_lsn - scan_start).
+        captured: list[int | None] = []
+        op = _make_restore_op(prepare_progress_callback=lambda **kw: captured.append(kw["pct"]))
+        op._prepare_last_lsn = 2000
+
+        self._feed(
+            op,
+            [
+                "InnoDB: Doing recovery: scanned up to log sequence number 1000",
+                "InnoDB: Doing recovery: scanned up to log sequence number 1500",
+                "InnoDB: Doing recovery: scanned up to log sequence number 1900",
+            ],
+        )
+        assert op.prepare_progress_pct == 90
+        assert captured == [0, 50, 90]
+
+    def test_ignores_non_scan_lines(self):
+        # Only "Doing recovery: scanned up to log sequence number N" drives progress.
+        # Other InnoDB lines that mention LSNs must not advance the bar.
+        op = _make_restore_op()
+        op._prepare_last_lsn = 1000
+        self._feed(
+            op,
+            [
+                "InnoDB: Applying log record at LSN 9999",
+                "InnoDB: Starting crash recovery from checkpoint LSN 500",
+            ],
+        )
+        assert op.prepare_progress_pct is None
+
+    def test_pct_never_regresses(self):
+        op = _make_restore_op()
+        op._prepare_last_lsn = 1000
+        self._feed(
+            op,
+            [
+                "InnoDB: Doing recovery: scanned up to log sequence number 500",
+                # Out-of-order smaller LSN must not pull the bar back.
+                "InnoDB: Doing recovery: scanned up to log sequence number 300",
+                "InnoDB: Doing recovery: scanned up to log sequence number 750",
+            ],
+        )
+        assert op.prepare_progress_pct == 50
+
+    def test_pct_pinned_at_100_on_shutdown_completed(self):
+        # "Shutdown completed" pins to 100% even when no scan line landed.
+        # scan_start gets seeded to prepared_lsn (>= last_lsn typically), so
+        # the property's span<=0 branch handles the negative span.
+        op = _make_restore_op()
+        op._prepare_last_lsn = 1000
+        op._process_prepare_output_line(b"Shutdown completed; log sequence number 2000", "stderr")
+        assert op.prepared_lsn == 2000
+        assert op.prepare_progress_pct == 100
+
+    def test_zero_range_does_not_divide_by_zero(self):
+        # One scan line at exactly last_lsn → denominator zero, pin at 100.
+        op = _make_restore_op()
+        op._prepare_last_lsn = 500
+        op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 500", "stderr")
+        assert op.prepare_progress_pct == 100
+
+    def test_no_checkpoints_means_no_pct_and_no_callback(self):
+        captured: list[int | None] = []
+        op = _make_restore_op(prepare_progress_callback=lambda **kw: captured.append(kw["pct"]))
+
+        self._feed(op, ["InnoDB: Doing recovery: scanned up to log sequence number 100"])
+        assert op.prepare_progress_pct is None
+        assert not captured
+
+    def test_callback_fires_only_on_pct_change(self):
+        # Dedupe at the integer-pct level: scan lines advance the LSN more
+        # often than the truncated pct, but the callback must fire once per
+        # whole-percent change.
+        pcts: list[int | None] = []
+        op = _make_restore_op(prepare_progress_callback=lambda **kw: pcts.append(kw["pct"]))
+        op._prepare_last_lsn = 1000
+
+        op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 500", "stderr")
+        op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 500", "stderr")
+        # Different LSN but same truncated pct (0%): must not re-fire.
+        op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 504", "stderr")
+        op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 700", "stderr")
+        # 40.6% → truncates to the same 40%: must not re-fire.
+        op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 703", "stderr")
+        assert pcts == [0, 40]
+
+    def test_metric_emitted_on_pct_change(self):
+        # Each integer pct change emits one gauge sample; the starting marker
+        # (lsn=None) bypasses the gauge since None isn't a meaningful value.
+        pcts: list[int | None] = []
+        op = _make_restore_op(prepare_progress_callback=lambda **kw: pcts.append(kw["pct"]))
+        op._prepare_last_lsn = 1000
+        with patch.object(op.stats, "gauge_int") as gauge:
+            op._set_prepare_current_lsn(None)
+            op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 500", "stderr")
+            op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 700", "stderr")
+            op._process_prepare_output_line(b"InnoDB: Doing recovery: scanned up to log sequence number 703", "stderr")
+        assert gauge.call_args_list == [
+            (("myhoard.basebackup_restore.xtrabackup_prepare_progress", 0), {}),
+            (("myhoard.basebackup_restore.xtrabackup_prepare_progress", 40), {}),
+        ]
+
+
 def test_get_xtrabackup_cmd():
     op_kwargs = {
         "encryption_algorithm": "AES256",
@@ -79,6 +215,7 @@ def test_basic_restore(mysql_master, mysql_empty):
             stream.close()
 
         with tempfile.TemporaryDirectory(dir=mysql_empty.base_dir, prefix="myhoard_target_") as temp_target_dir:
+            progress_pcts: list[int | None] = []
             restore_op = BasebackupRestoreOperation(
                 encryption_algorithm="AES256",
                 encryption_key=encryption_key,
@@ -90,11 +227,15 @@ def test_basic_restore(mysql_master, mysql_empty):
                 target_dir=temp_target_dir,
                 temp_dir=mysql_empty.base_dir,
                 backup_tool_version=xtrabackup_version_to_string(myhoard_util.get_xtrabackup_version()),
+                prepare_progress_callback=lambda *, pct: progress_pcts.append(pct),
             )
-            restore_op.prepare_backup()
+            restore_op.prepare_backup(checkpoints_file_content=backup_op.checkpoints_file_content)
             restore_op.restore_backup()
 
         assert restore_op.number_of_files >= backup_op.number_of_files
+        assert progress_pcts[0] is None
+        assert progress_pcts[-1] == 100
+        assert restore_op.prepare_progress_pct == 100
 
     mysql_empty.proc = subprocess.Popen(mysql_empty.startup_command)  # pylint: disable=consider-using-with
     wait_for_port(mysql_empty.port)

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -2649,3 +2649,54 @@ def test_get_backup_to_purge(
         assert controller._get_backup_to_purge() == controller.state["backups"][0]
     else:
         assert controller._get_backup_to_purge() == expected_no_purge_reason
+
+
+class TestIsSafeToReload:
+    """Unit tests for Controller.is_safe_to_reload, constructed via __new__
+    with only the attributes the method touches."""
+
+    def _make_controller(self, *, phase=None, basebackup_stream=False):
+        import logging
+        import threading
+
+        controller = Controller.__new__(Controller)
+        controller.lock = threading.RLock()
+        controller.log = logging.getLogger("controller-reload-test")
+        controller.restore_coordinator = None
+        controller.backup_streams = []
+        if phase is not None:
+            coord = MagicMock()
+            coord.phase = phase
+            controller.restore_coordinator = coord
+        if basebackup_stream:
+            stream = MagicMock()
+            stream.active_phase = BackupStream.ActivePhase.basebackup
+            controller.backup_streams = [stream]
+        return controller
+
+    def test_safe_when_idle(self):
+        assert self._make_controller().is_safe_to_reload()
+
+    def test_unsafe_while_restoring_basebackup(self):
+        controller = self._make_controller(phase=RestoreCoordinator.Phase.restoring_basebackup)
+        assert not controller.is_safe_to_reload()
+
+    def test_unsafe_while_preparing_backup(self):
+        # Reload during --prepare would rewind to restoring_basebackup and
+        # re-run extract + prepare + move-back from scratch.
+        controller = self._make_controller(phase=RestoreCoordinator.Phase.preparing_backup)
+        assert not controller.is_safe_to_reload()
+
+    def test_safe_in_later_restore_phases(self):
+        # Phases after --prepare are independently resumable.
+        for phase in (
+            RestoreCoordinator.Phase.rebuilding_tables,
+            RestoreCoordinator.Phase.applying_binlogs,
+            RestoreCoordinator.Phase.finalizing,
+            RestoreCoordinator.Phase.completed,
+        ):
+            controller = self._make_controller(phase=phase)
+            assert controller.is_safe_to_reload(), f"expected safe in phase {phase}"
+
+    def test_unsafe_while_taking_basebackup(self):
+        assert not self._make_controller(basebackup_stream=True).is_safe_to_reload()

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -606,3 +606,42 @@ def test_basebackup_bytes_total(
     )
     rc.update_state(basebackup_info=basebackup_info, required_backups=required_backups)
     assert rc.basebackup_bytes_total == expected_bytes_total
+
+
+def _make_minimal_coordinator(session_tmpdir):
+    return RestoreCoordinator(
+        binlog_streams=[],
+        download_workers_count=2,
+        file_storage_config={},
+        free_memory_percentage=80,
+        mysql_client_params="-",
+        mysql_config_file_name="-",
+        mysql_data_directory="/dev/null",
+        mysql_relay_log_index_file="/dev/null",
+        mysql_relay_log_prefix="/dev/null",
+        pending_binlogs_state_file="/dev/null",
+        rebuild_tables=False,
+        restart_mysqld_callback=lambda **kwargs: None,
+        rsa_private_key_pem="/dev/null",
+        site="default",
+        state_file=os.path.join(session_tmpdir().strpath, "the_state_file.json"),
+        stats=build_statsd_client(),
+        stream_id="-",
+        temp_dir=session_tmpdir().strpath,
+    )
+
+
+def test_on_prepare_progress_flips_phase_and_persists_pct(session_tmpdir):
+    # pylint: disable=protected-access
+    rc = _make_minimal_coordinator(session_tmpdir)
+    # First pct=None call (at xtrabackup --prepare Popen) flips phase and
+    # wipes any leftover pct from a previous required-backup iteration.
+    rc.update_state(phase=RestoreCoordinator.Phase.restoring_basebackup, basebackup_prepare_progress=42)
+    rc._on_prepare_progress(pct=None)
+    assert rc.state["phase"] == RestoreCoordinator.Phase.preparing_backup
+    assert rc.state["basebackup_prepare_progress"] is None
+
+    rc._on_prepare_progress(pct=37)
+    assert rc.state["basebackup_prepare_progress"] == 37
+    rc._on_prepare_progress(pct=88)
+    assert rc.state["basebackup_prepare_progress"] == 88

--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -166,6 +166,7 @@ async def test_status_update_to_restore(master_controller, web_client):
         assert isinstance(response["binlogs_restored"], int)
         # Operation will fail because we faked the backup info
         assert response["phase"] != RestoreCoordinator.Phase.failed
+        assert "basebackup_prepare_progress" in response
 
     master_controller[0].state["backups"].append(
         {"stream_id": "abc", "site": "default", "basebackup_info": {"end_ts": 1234567}}


### PR DESCRIPTION
On multi-TB MySQL restores `xtrabackup --prepare` can run for hours between the basebackup download finishing and the database becoming available. From the outside the restore looks stuck — the bytes-downloaded gauge is pinned at 100% and there's no other signal.                 
                                                                                                                                                                                                                                                                                          
  This PR adds a `RestoreCoordinator.Phase.preparing_backup` entered during `restore_basebackup()` once `xbstream` extract is done and `xtrabackup --prepare` (followed by the short `--move-back`) starts running. The pct is derived from the InnoDB scan-line LSN advancing across     
  `[first observed scan LSN, last_lsn from xtrabackup_checkpoints]`. `last_lsn` is the redo stop LSN — using `to_lsn` would hit 100% before the redo tail is applied; the lower bound is the first observed scan LSN rather than `from_lsn`, which is `0` on full backups and would pin   
  the bar near the top of the range.                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                          
  `BasebackupRestoreOperation` parses `xtrabackup` output, derives the pct, and fires a callback when the integer pct changes (deduped at the pct level — at most ~101 emissions per run). The coordinator's callback updates `state["basebackup_prepare_progress"]` and sets             
  `Phase.preparing_backup`; the first call carries `pct=None` and is what flips the phase from `restoring_basebackup`.                                                                                                                                                                    
                                                                                                                                                                                                                                                                                          
  `/status/restore` exposes `basebackup_prepare_progress`, gated on the live phase so failure paths (`Phase.failed`, `Phase.failed_basebackup`) don't leak a stale pct. `Controller.is_safe_to_reload` now also blocks reload during `preparing_backup`; neither it nor                   
  `restoring_basebackup` is independently resumable, so a reload would discard hours of work. A `myhoard.basebackup_restore.xtrabackup_prepare_progress` gauge is emitted alongside the callback so dashboards can show in-flight progress without polling `/status/restore`.  