### PR TITLE
Allow restoring into an empty existing data directory

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -501,7 +501,10 @@ class RestoreCoordinator(threading.Thread):
 
     def restore_basebackup(self) -> None:
         if os.path.exists(self.mysql_data_directory):
-            raise ValueError(f"MySQL data directory {self.mysql_data_directory!r} already exists")
+            if not os.path.isdir(self.mysql_data_directory):
+                raise ValueError(f"MySQL data directory {self.mysql_data_directory!r} already exists and is not a directory")
+            if os.listdir(self.mysql_data_directory):
+                raise ValueError(f"MySQL data directory {self.mysql_data_directory!r} already exists and is not empty")
 
         start_time = time.monotonic()
         restore_basebackup_info = self.state["basebackup_info"]

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -503,8 +503,9 @@ class RestoreCoordinator(threading.Thread):
         if os.path.exists(self.mysql_data_directory):
             if not os.path.isdir(self.mysql_data_directory):
                 raise ValueError(f"MySQL data directory {self.mysql_data_directory!r} already exists and is not a directory")
-            if os.listdir(self.mysql_data_directory):
-                raise ValueError(f"MySQL data directory {self.mysql_data_directory!r} already exists and is not empty")
+            with os.scandir(self.mysql_data_directory) as entries:
+                if next(entries, None) is not None:
+                    raise ValueError(f"MySQL data directory {self.mysql_data_directory!r} already exists and is not empty")
 
         start_time = time.monotonic()
         restore_basebackup_info = self.state["basebackup_info"]

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -479,6 +479,78 @@ def test_should_mark_backup_as_broken(session_tmpdir):
     assert rc.should_mark_backup_as_broken()
 
 
+def test_restore_basebackup_allows_empty_existing_mysql_data_directory(session_tmpdir):
+    state_file = os.path.join(session_tmpdir().strpath, "restore_coordinator.json")
+    mysql_data_directory = os.path.join(session_tmpdir().strpath, "mysql-data")
+    temp_dir = os.path.join(session_tmpdir().strpath, "temp")
+    os.makedirs(mysql_data_directory)
+    os.makedirs(temp_dir)
+
+    rc = RestoreCoordinator(
+        binlog_streams=[],
+        download_workers_count=2,
+        file_storage_config={},
+        free_memory_percentage=80,
+        mysql_client_params={},
+        mysql_config_file_name="",
+        mysql_data_directory=mysql_data_directory,
+        mysql_relay_log_index_file="",
+        mysql_relay_log_prefix="",
+        pending_binlogs_state_file=os.path.join(session_tmpdir().strpath, "restore_coordinator.pending_binlogs"),
+        rebuild_tables=False,
+        restart_mysqld_callback=lambda **kwargs: None,
+        rsa_private_key_pem="",
+        site="default",
+        state_file=state_file,
+        stats=build_statsd_client(),
+        stream_id="stream-id",
+        target_time=None,
+        temp_dir=temp_dir,
+    )
+    rc.state["basebackup_info"] = {}
+
+    with patch.object(rc, "_run_basebackup_restore_operation") as mock_restore:
+        rc.restore_basebackup()
+
+    mock_restore.assert_called_once()
+    assert rc.state["phase"] == RestoreCoordinator.Phase.refreshing_binlogs
+
+
+def test_restore_basebackup_rejects_nonempty_existing_mysql_data_directory(session_tmpdir):
+    state_file = os.path.join(session_tmpdir().strpath, "restore_coordinator.json")
+    mysql_data_directory = os.path.join(session_tmpdir().strpath, "mysql-data")
+    temp_dir = os.path.join(session_tmpdir().strpath, "temp")
+    os.makedirs(mysql_data_directory)
+    os.makedirs(temp_dir)
+    with open(os.path.join(mysql_data_directory, "existing-file"), "w", encoding="utf-8") as existing_file:
+        existing_file.write("content")
+
+    rc = RestoreCoordinator(
+        binlog_streams=[],
+        download_workers_count=2,
+        file_storage_config={},
+        free_memory_percentage=80,
+        mysql_client_params={},
+        mysql_config_file_name="",
+        mysql_data_directory=mysql_data_directory,
+        mysql_relay_log_index_file="",
+        mysql_relay_log_prefix="",
+        pending_binlogs_state_file=os.path.join(session_tmpdir().strpath, "restore_coordinator.pending_binlogs"),
+        rebuild_tables=False,
+        restart_mysqld_callback=lambda **kwargs: None,
+        rsa_private_key_pem="",
+        site="default",
+        state_file=state_file,
+        stats=build_statsd_client(),
+        stream_id="stream-id",
+        target_time=None,
+        temp_dir=temp_dir,
+    )
+
+    with pytest.raises(ValueError, match="already exists and is not empty"):
+        rc.restore_basebackup()
+
+
 def test_restore_coordinator_check_parameter_before_restart(session_tmpdir):
     # pylint: disable=W0212,W0108
     restarts = []


### PR DESCRIPTION

 ## What changed

RestoreCoordinator now allows restoring into an existing MySQL data directory when that directory is empty.

The previous behavior rejected any pre-existing path unconditionally. The new behavior keeps the safety check for existing content, but permits reuse of an already-created empty directory.

## Why

In some environments the target data directory may already exist before restore starts. Rejecting that case prevents restore even when the directory is safe to use.

This change keeps the guard against accidental overwrite by continuing to reject non-empty directories and non-directory paths.

## Tests

- added a unit test that allows restore when the target directory already exists and is empty
- added a unit test that still rejects restore when the target directory already exists and contains files