### PR TITLE
Fix myhoard for Python 3.14

### DIFF
--- a/myhoard/myhoard.py
+++ b/myhoard/myhoard.py
@@ -36,7 +36,7 @@ class MyHoard:
         self.controller = None
         self.is_running = True
         self.log = logging.getLogger(self.__class__.__name__)
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.new_event_loop()
         self.mysqld_pid = None
         self.reload_retry_interval = 10
         self.reloading = False
@@ -78,6 +78,7 @@ class MyHoard:
             self.reloading = False
 
     def run(self):
+        asyncio.set_event_loop(self.loop)
         self.loop.add_signal_handler(signal.SIGHUP, self.request_reload)
         self.loop.add_signal_handler(signal.SIGINT, self.request_shutdown)
         self.loop.add_signal_handler(signal.SIGTERM, self.request_shutdown)


### PR DESCRIPTION
On Python 3.14, `self.loop = asyncio.get_event_loop() in myhoard/myhoard.py` will raise `RuntimeError: There is no current event loop in thread 'MainThread'`

This commit allows myhoard to run on Python 3.14 by using
```
self.loop = asyncio.new_event_loop()
asyncio.set_event_loop(self.loop)
````
instead

# About this change: What it does, why it matters

Make myhoard compatible with Python 3.14

Reference: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop
> Changed in version 3.14: Raises a [RuntimeError] if there is no current event loop.
