### PR TITLE
Add estimate_memory xtrabackup setting for Smart memory estimation [MYC-106]

### DIFF
--- a/myhoard.json
+++ b/myhoard.json
@@ -75,6 +75,7 @@
         "copy_threads": 1,
         "compress_threads": 1,
         "encrypt_threads": 1,
+        "estimate_memory": false,
         "register_redo_log_consumer": false
     }
 }

--- a/myhoard/backup_stream.py
+++ b/myhoard/backup_stream.py
@@ -1035,6 +1035,7 @@ class BackupStream(threading.Thread):
             encrypt_threads=self.xtrabackup_settings["encrypt_threads"],
             encryption_algorithm="AES256",
             encryption_key=encryption_key,
+            estimate_memory=self.xtrabackup_settings["estimate_memory"],
             mysql_client_params=self.mysql_client_params,
             mysql_config_file_name=self.mysql_config_file_name,
             mysql_data_directory=self.mysql_data_directory,

--- a/myhoard/basebackup_operation.py
+++ b/myhoard/basebackup_operation.py
@@ -4,7 +4,7 @@ from myhoard.errors import BlockMismatchError, XtraBackupError
 from myhoard.util import CHECKPOINT_FILENAME, get_mysql_version, mysql_cursor, parse_xtrabackup_info
 from packaging.version import Version
 from rohmu.util import increase_pipe_capacity, set_stream_nonblocking
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import base64
 import logging
@@ -52,6 +52,7 @@ class BasebackupOperation:
         encrypt_threads=1,
         encryption_algorithm,
         encryption_key,
+        estimate_memory=False,
         mysql_client_params,
         mysql_config_file_name,
         mysql_data_directory,
@@ -75,6 +76,7 @@ class BasebackupOperation:
         self.encrypt_threads = encrypt_threads
         self.encryption_algorithm = encryption_algorithm
         self.encryption_key = encryption_key
+        self.estimate_memory = estimate_memory
         self.has_block_mismatch = False
         self.log = logging.getLogger(self.__class__.__name__)
         self.incremental_since_checkpoint = incremental_since_checkpoint
@@ -127,29 +129,10 @@ class BasebackupOperation:
 
                 self.temp_dir = tempfile.mkdtemp(dir=self.temp_dir_base, prefix="xtrabackup")
                 self.lsn_dir = tempfile.mkdtemp(dir=self.temp_dir_base, prefix="xtrabackupmeta")
-                command_line = [
-                    "xtrabackup",
-                    # defaults file must be given with --defaults-file=foo syntax, space here does not work
-                    f"--defaults-file={mysql_config_file.name}",
-                    "--backup",
-                    "--compress",
-                    f"--compress-threads={self.compress_threads}",
-                    "--encrypt",
-                    self.encryption_algorithm,
-                    f"--encrypt-threads={self.encrypt_threads}",
-                    "--encrypt-key-file",
-                    encryption_key_file.name,
-                    "--no-version-check",
-                    f"--parallel={self.copy_threads}",
-                    "--stream=xbstream",
-                    "--target-dir",
-                    self.temp_dir,
-                    "--extra-lsndir",
-                    self.lsn_dir,
-                ]
-
-                if self.register_redo_log_consumer:
-                    command_line.append("--register-redo-log-consumer")
+                command_line = self._build_backup_command_line(
+                    mysql_config_file_name=mysql_config_file.name,
+                    encryption_key_file_name=encryption_key_file.name,
+                )
 
                 if self.incremental_since_checkpoint:
                     self.prev_checkpoint_dir = tempfile.mkdtemp(dir=self.temp_dir_base, prefix="xtrabackupcheckpoint")
@@ -168,6 +151,38 @@ class BasebackupOperation:
 
         self.data_directory_size_end, self.data_directory_filtered_size = self._get_data_directory_size()
         self._update_progress(estimated_progress=100)
+
+    def _build_backup_command_line(self, *, mysql_config_file_name: str, encryption_key_file_name: str) -> List[str]:
+        command_line = [
+            "xtrabackup",
+            # defaults file must be given with --defaults-file=foo syntax, space here does not work
+            f"--defaults-file={mysql_config_file_name}",
+            "--backup",
+            "--compress",
+            f"--compress-threads={self.compress_threads}",
+            "--encrypt",
+            self.encryption_algorithm,
+            f"--encrypt-threads={self.encrypt_threads}",
+            "--encrypt-key-file",
+            encryption_key_file_name,
+            "--no-version-check",
+            f"--parallel={self.copy_threads}",
+            "--stream=xbstream",
+            "--target-dir",
+            self.temp_dir,
+            "--extra-lsndir",
+            self.lsn_dir,
+        ]
+
+        if self.register_redo_log_consumer:
+            command_line.append("--register-redo-log-consumer")
+
+        # Smart memory estimation (tech preview). Must be enabled at backup time so that the restore-side
+        # `xtrabackup --prepare --use-free-memory-pct` is honoured; without it that flag is ignored.
+        if self.estimate_memory:
+            command_line.append("--estimate-memory=ON")
+
+        return command_line
 
     def is_incremental(self) -> bool:
         return self.incremental_since_checkpoint is not None

--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -38,6 +38,7 @@ DEFAULT_XTRABACKUP_SETTINGS = {
     "copy_threads": 1,
     "compress_threads": 1,
     "encrypt_threads": 1,
+    "estimate_memory": False,
     "register_redo_log_consumer": False,
 }
 

--- a/test/test_basebackup_operation.py
+++ b/test/test_basebackup_operation.py
@@ -284,3 +284,38 @@ def test_process_binlog_info(mysql_master: MySQLConfig) -> None:
         "file_position": 238,
         "gtid": None,
     }
+
+
+def _make_backup_op(*, estimate_memory: bool = False) -> BasebackupOperation:
+    # /dev/null is read for the mysql config at construction time; no live server or subprocess is needed.
+    op = BasebackupOperation(
+        encryption_algorithm="AES256",
+        encryption_key=b"0" * 24,
+        estimate_memory=estimate_memory,
+        mysql_client_params={"host": "127.0.0.1"},
+        mysql_config_file_name="/dev/null",
+        mysql_data_directory="/dev/null",
+        stats=build_statsd_client(),
+        stream_handler=None,
+        temp_dir="/tmp",
+    )
+    op.temp_dir = "/tmp/xtrabackup"
+    op.lsn_dir = "/tmp/xtrabackupmeta"
+    return op
+
+
+def test_build_backup_command_line_estimate_memory_off_by_default() -> None:
+    op = _make_backup_op()
+    command_line = op._build_backup_command_line(  # pylint: disable=protected-access
+        mysql_config_file_name="/etc/mysql/my.cnf", encryption_key_file_name="/tmp/key.bin"
+    )
+    assert "--backup" in command_line
+    assert "--estimate-memory=ON" not in command_line
+
+
+def test_build_backup_command_line_estimate_memory_enabled() -> None:
+    op = _make_backup_op(estimate_memory=True)
+    command_line = op._build_backup_command_line(  # pylint: disable=protected-access
+        mysql_config_file_name="/etc/mysql/my.cnf", encryption_key_file_name="/tmp/key.bin"
+    )
+    assert "--estimate-memory=ON" in command_line


### PR DESCRIPTION
## What

Adds an `estimate_memory` xtrabackup setting. When enabled, myhoard passes `--estimate-memory=ON` to `xtrabackup --backup`.

This is the **backup-side half** of Percona XtraBackup's [Smart memory estimation](https://docs.percona.com/percona-xtrabackup/8.0/smart-memory-estimation.html) (tech preview). The restore side — `--use-free-memory-pct` — is already supported (`BasebackupRestoreOperation`, driven by `restore_free_memory_percentage`), but xtrabackup **ignores** `--use-free-memory-pct` at prepare time unless the backup was taken with `--estimate-memory=ON`. So the two must be enabled together; this PR closes the gap.

## Why

The `xtrabackup --prepare` phase otherwise runs at the ~100MB default buffer, which is slow on large restores. Smart memory estimation lets prepare use a configurable share of free memory (Percona reports ~10–17x faster prepare in their environment). Enabling it requires turning on estimate-memory **at backup time**.

## Compatibility

- Default off → existing backups and callers unaffected.
- Feature is PXB tech preview; introduced in PXB 8.0.30-23, `--estimate-memory` option in 8.0.32-26. The restore side already version-gates `--use-free-memory-pct` to `>= 8.0.32`.