### PR TITLE
Bound per-cycle binlog purge to avoid LOCK_index write stalls

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,8 +50,8 @@ jobs:
       # skipping matrix items that aren't meaningful
       matrix:
         include:
-          - mysql-version: "8.0.35"
-            percona-version: "8.0.35-30-1.jammy"
+          - mysql-version: "8.0.45"
+            percona-version: "8.0.35-36-1.jammy"
             python-version: "3.12"
             ubuntu-version: "22.04"
           - mysql-version: "8.4.8"

--- a/README.md
+++ b/README.md
@@ -301,6 +301,25 @@ needing.
 
 Number of seconds between checks for binary logs that could be removed.
 
+**binlog_purge_settings.max_files_per_cycle**
+
+Maximum number of binary log files to purge in a single purge cycle. When a large
+backlog of binary logs becomes eligible for purging at once (for example after
+lowering `min_binlog_age_before_purge`), purging them all in one
+`PURGE BINARY LOGS` statement makes MySQL hold `LOCK_index` for the entire
+operation, which stalls all committing transactions until it completes. Bounding
+the number of files per cycle spreads a large backlog over many successive
+`purge_interval` ticks, each holding the lock only briefly. The oldest eligible
+files are always purged first. Set to `null` to disable the file-count limit.
+
+**binlog_purge_settings.max_bytes_per_cycle**
+
+Maximum total size, in bytes, of binary log files to purge in a single purge
+cycle. This works together with `max_files_per_cycle`; whichever limit is reached
+first bounds the cycle. At least one file is always purged even if it alone
+exceeds this limit, so purging always makes forward progress. Set to `null` to
+disable the byte-size limit.
+
 **binlog_purge_settings.purge_when_observe_no_streams**
 
 Allow purging binary logs when no active backups exist. This setting is mostly
@@ -914,6 +933,8 @@ The following metrics are exported by myhoard:
 **myhoard.basebackup_restore.xtrabackup_prepare**
 **myhoard.binlog.count**
 **myhoard.binlog.count_new**
+**myhoard.binlog.purged_per_cycle.bytes**
+**myhoard.binlog.purged_per_cycle.files**
 **myhoard.binlog.remote_copy**
 **myhoard.binlog.removed**
 **myhoard.binlog.size**

--- a/myhoard.json
+++ b/myhoard.json
@@ -33,6 +33,8 @@
         "enabled": true,
         "min_binlog_age_before_purge": 600,
         "purge_interval": 60,
+        "max_files_per_cycle": 50,
+        "max_bytes_per_cycle": 5368709120,
         "purge_when_observe_no_streams": true
     },
     "http_address": "127.0.0.1",

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -618,10 +618,17 @@ class Controller(threading.Thread):
 
         Returns the longest prefix that satisfies both max_files_per_cycle and max_bytes_per_cycle. At least one
         binlog is always kept (even if it alone exceeds max_bytes_per_cycle) so that purging always makes forward
-        progress. A cap of None (or absent) means unbounded for that dimension.
+        progress. A cap that is None, absent or non-positive means unbounded for that dimension.
         """
         max_files = purge_settings.get("max_files_per_cycle")
         max_bytes = purge_settings.get("max_bytes_per_cycle")
+        # A cap only takes effect when it is a positive number. Normalize any non-positive value to None (no limit)
+        # so both dimensions behave consistently: otherwise max_bytes_per_cycle=0 would still purge a single file
+        # due to the forward-progress guarantee below, while max_files_per_cycle=0 would purge nothing at all.
+        if max_files is not None and max_files <= 0:
+            max_files = None
+        if max_bytes is not None and max_bytes <= 0:
+            max_bytes = None
         if (max_files is None and max_bytes is None) or not binlogs_to_purge:
             return binlogs_to_purge
 

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -605,7 +605,47 @@ class Controller(threading.Thread):
                     binlogs_to_purge.append(binlog)
                 else:
                     break
+        # Bound the per-cycle purge so a large eligible backlog is drained as many small purges across successive
+        # ticks instead of a single PURGE BINARY LOGS covering the whole backlog (which holds LOCK_index, stalling
+        # all writes, for the entire duration). binlogs_to_purge is a contiguous oldest-first prefix and any
+        # shorter prefix is equally safe to purge, so we simply truncate it to satisfy whichever cap is hit first.
+        binlogs_to_purge = cls._cap_binlogs_to_purge(binlogs_to_purge, purge_settings=purge_settings, log=log)
         return binlogs_to_purge, bool(only_binlogs_without_gtids or only_binlogs_that_are_too_new)
+
+    @staticmethod
+    def _cap_binlogs_to_purge(binlogs_to_purge, *, purge_settings, log):
+        """Trim a contiguous oldest-first list of purgeable binlogs to the per-cycle caps.
+
+        Returns the longest prefix that satisfies both max_files_per_cycle and max_bytes_per_cycle. At least one
+        binlog is always kept (even if it alone exceeds max_bytes_per_cycle) so that purging always makes forward
+        progress. A cap of None (or absent) means unbounded for that dimension.
+        """
+        max_files = purge_settings.get("max_files_per_cycle")
+        max_bytes = purge_settings.get("max_bytes_per_cycle")
+        if (max_files is None and max_bytes is None) or not binlogs_to_purge:
+            return binlogs_to_purge
+
+        capped = []
+        total_bytes = 0
+        for binlog in binlogs_to_purge:
+            if max_files is not None and len(capped) >= max_files:
+                break
+            binlog_size = binlog.get("file_size", 0)
+            if max_bytes is not None and capped and total_bytes + binlog_size > max_bytes:
+                break
+            capped.append(binlog)
+            total_bytes += binlog_size
+
+        if len(capped) < len(binlogs_to_purge):
+            log.info(
+                "Capping per-cycle purge to %s/%s binlogs (%s bytes); max_files_per_cycle=%s max_bytes_per_cycle=%s",
+                len(capped),
+                len(binlogs_to_purge),
+                total_bytes,
+                max_files,
+                max_bytes,
+            )
+        return capped
 
     @staticmethod
     def get_backup_list(backup_sites: Dict[str, BackupSiteInfo], *, seen_basebackup_infos=None, site_transfers=None):
@@ -1659,6 +1699,13 @@ class Controller(threading.Thread):
                     raise
                 last_purge = time.time()
                 last_could_have_purged = last_purge
+                # Report the per-cycle purge batch size so we can verify the per-cycle caps are engaging in
+                # production (a large eligible backlog should drain across many bounded ticks, not one big purge).
+                self.stats.gauge_int("myhoard.binlog.purged_per_cycle.files", len(binlogs_to_purge))
+                self.stats.gauge_int(
+                    "myhoard.binlog.purged_per_cycle.bytes",
+                    sum(binlog.get("file_size", 0) for binlog in binlogs_to_purge),
+                )
             else:
                 # If we only had binlogs for which we legitimately couldn't tell whether purging was safe or not,
                 # or which according to settings should not have been purged, update the could have purged timestamp

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -396,6 +396,8 @@ def fixture_myhoard_config(default_backup_site, mysql_master, session_tmpdir):
             "enabled": True,
             "min_binlog_age_before_purge": 600,
             "purge_interval": 60,
+            "max_files_per_cycle": 50,
+            "max_bytes_per_cycle": 5368709120,
             "purge_when_observe_no_streams": True,
         },
         "http_address": "127.0.0.1",

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1623,6 +1623,20 @@ def test_cap_binlogs_to_purge_passthrough_when_unset():
     assert not cap([], purge_settings={"max_files_per_cycle": 1}, log=MagicMock())
 
 
+def test_cap_binlogs_to_purge_non_positive_caps_mean_unbounded():
+    # A non-positive cap must behave identically to no cap for both dimensions (consistency at the zero boundary):
+    # neither 0 nor a negative value should ever purge fewer files than "unlimited" would.
+    cap = Controller._cap_binlogs_to_purge  # pylint: disable=protected-access
+    binlogs = _make_purgeable_binlogs(5, file_size=100)
+    for settings in (
+        {"max_files_per_cycle": 0, "max_bytes_per_cycle": 0},
+        {"max_files_per_cycle": -1, "max_bytes_per_cycle": -1},
+        {"max_files_per_cycle": 0, "max_bytes_per_cycle": None},
+        {"max_files_per_cycle": None, "max_bytes_per_cycle": 0},
+    ):
+        assert cap(binlogs, purge_settings=settings, log=MagicMock()) == binlogs
+
+
 def test_periodic_backup_based_on_exceeded_intervals(time_machine, master_controller) -> None:
     # pylint: disable=protected-access
     time_machine.move_to("2023-01-02T18:00:00")

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1511,6 +1511,118 @@ def test_collect_binlogs_to_purge():
     log.info.assert_any_call("Binlog %s has been replicated to all servers, purging", 3)
 
 
+def _make_purgeable_binlogs(count, *, file_size=1, now=None):
+    # Build binlogs that collect_binlogs_to_purge will consider fully eligible: old enough, GTIDs present, and
+    # (combined with a replication_state covering them) replicated everywhere.
+    now = now if now is not None else time.time()
+    return [
+        {
+            "local_index": index,
+            "file_name": f"bin.{index:06d}",
+            "file_size": file_size,
+            "gtid_ranges": [{"server_uuid": "uuid1", "start": index, "end": index}],
+            "processed_at": now - 100,
+        }
+        for index in range(1, count + 1)
+    ]
+
+
+def _collect_all_eligible(binlogs, purge_settings):
+    bs = MagicMock()
+    bs.is_binlog_safe_to_delete.return_value = True
+    replication_state = {"server1": {"uuid1": [[1, len(binlogs)]]}}
+    return Controller.collect_binlogs_to_purge(
+        backup_streams=[bs],
+        binlogs=binlogs,
+        log=MagicMock(),
+        mode=Controller.Mode.active,
+        purge_settings=purge_settings,
+        replication_state=replication_state,
+    )
+
+
+def test_collect_binlogs_to_purge_caps_by_file_count():
+    binlogs = _make_purgeable_binlogs(10, file_size=1)
+    purge_settings = {"min_binlog_age_before_purge": 5, "max_files_per_cycle": 3, "max_bytes_per_cycle": None}
+    binlogs_to_purge, only_inapplicable_binlogs = _collect_all_eligible(binlogs, purge_settings)
+    # Exactly the oldest 3 files, contiguous from the oldest end.
+    assert binlogs_to_purge == binlogs[:3]
+    assert only_inapplicable_binlogs is False
+
+
+def test_collect_binlogs_to_purge_caps_by_bytes():
+    binlogs = _make_purgeable_binlogs(10, file_size=100)
+    # 250 bytes fits 2 full files (200) but not a 3rd (300 > 250).
+    purge_settings = {"min_binlog_age_before_purge": 5, "max_files_per_cycle": None, "max_bytes_per_cycle": 250}
+    binlogs_to_purge, _ = _collect_all_eligible(binlogs, purge_settings)
+    assert binlogs_to_purge == binlogs[:2]
+
+    # A single file larger than the byte cap is still purged so we always make forward progress.
+    purge_settings["max_bytes_per_cycle"] = 10
+    binlogs_to_purge, _ = _collect_all_eligible(binlogs, purge_settings)
+    assert binlogs_to_purge == binlogs[:1]
+
+
+def test_collect_binlogs_to_purge_caps_with_no_gtid_tail():
+    # A run of no-GTID binlogs gets flushed into binlogs_to_purge once a later GTID binlog is confirmed
+    # replicated. The cap must count those flushed entries and still yield a contiguous oldest-first prefix.
+    now = time.time()
+    binlogs = [
+        {"local_index": 1, "file_name": "bin.000001", "file_size": 1, "gtid_ranges": [], "processed_at": now - 100},
+        {"local_index": 2, "file_name": "bin.000002", "file_size": 1, "gtid_ranges": [], "processed_at": now - 100},
+        {
+            "local_index": 3,
+            "file_name": "bin.000003",
+            "file_size": 1,
+            "gtid_ranges": [{"server_uuid": "uuid1", "start": 1, "end": 1}],
+            "processed_at": now - 100,
+        },
+        {
+            "local_index": 4,
+            "file_name": "bin.000004",
+            "file_size": 1,
+            "gtid_ranges": [{"server_uuid": "uuid1", "start": 2, "end": 2}],
+            "processed_at": now - 100,
+        },
+    ]
+    bs = MagicMock()
+    bs.is_binlog_safe_to_delete.return_value = True
+    replication_state = {"server1": {"uuid1": [[1, 2]]}}
+    purge_settings = {"min_binlog_age_before_purge": 5, "max_files_per_cycle": 2, "max_bytes_per_cycle": None}
+    binlogs_to_purge, _ = Controller.collect_binlogs_to_purge(
+        backup_streams=[bs],
+        binlogs=binlogs,
+        log=MagicMock(),
+        mode=Controller.Mode.active,
+        purge_settings=purge_settings,
+        replication_state=replication_state,
+    )
+    # The two leading no-GTID files are flushed when binlog 3 is confirmed replicated; the cap keeps the oldest 2.
+    assert binlogs_to_purge == binlogs[:2]
+
+
+def test_collect_binlogs_to_purge_no_change_below_caps():
+    binlogs = _make_purgeable_binlogs(5, file_size=100)
+    uncapped, uncapped_inapplicable = _collect_all_eligible(
+        binlogs, {"min_binlog_age_before_purge": 5, "max_files_per_cycle": None, "max_bytes_per_cycle": None}
+    )
+    capped, capped_inapplicable = _collect_all_eligible(
+        binlogs, {"min_binlog_age_before_purge": 5, "max_files_per_cycle": 50, "max_bytes_per_cycle": 5 << 30}
+    )
+    assert uncapped == binlogs
+    assert capped == uncapped
+    assert capped_inapplicable == uncapped_inapplicable
+
+
+def test_cap_binlogs_to_purge_passthrough_when_unset():
+    cap = Controller._cap_binlogs_to_purge  # pylint: disable=protected-access
+    binlogs = _make_purgeable_binlogs(5, file_size=100)
+    # No caps configured at all -> the list is returned unchanged.
+    assert cap(binlogs, purge_settings={}, log=MagicMock()) == binlogs
+    # Empty input is returned unchanged regardless of caps.
+    assert not cap([], purge_settings={"max_files_per_cycle": 1}, log=MagicMock())
+
+
 def test_periodic_backup_based_on_exceeded_intervals(time_machine, master_controller) -> None:
     # pylint: disable=protected-access
     time_machine.move_to("2023-01-02T18:00:00")


### PR DESCRIPTION
Reducing binlog_retention_period on a write-heavy service made the next 60s purge tick collect the entire newly-eligible backlog and issue one PURGE BINARY LOGS over all of it. MySQL runs that under LOCK_index, which every committing transaction also needs, so a large backlog stalls all writes for the full purge duration (hours / >1 TB).

Cap each purge cycle by file count and total bytes so a large backlog drains as many small purges across successive ticks instead of one long stall. The cap trims the tail of the already-computed contiguous oldest-first prefix, so all existing safety semantics (stream safety, min_binlog_age_before_purge, replication state, no-GTID handling) are preserved. At least one file is always purged to guarantee progress.

Also emit myhoard.binlog.purged_per_cycle.{files,bytes} so the cap can be verified.