### PR TITLE
Drain capped binlog purge backlog promptly with optional inter-chunk delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,12 @@ backlog of binary logs becomes eligible for purging at once (for example after
 lowering `min_binlog_age_before_purge`), purging them all in one
 `PURGE BINARY LOGS` statement makes MySQL hold `LOCK_index` for the entire
 operation, which stalls all committing transactions until it completes. Bounding
-the number of files per cycle spreads a large backlog over many successive
-`purge_interval` ticks, each holding the lock only briefly. The oldest eligible
-files are always purged first. Set to `null` to disable the file-count limit.
+the number of files per cycle breaks a large backlog into many small purges, each
+holding the lock only briefly. When a cycle is capped and more safely-purgeable
+binary logs remain, the next chunk runs on the following control-loop tick without
+waiting for `purge_interval`, so a large backlog drains one chunk per tick instead
+of one chunk per interval. The oldest eligible files are always purged first. Set
+to `null` to disable the file-count limit.
 
 **binlog_purge_settings.max_bytes_per_cycle**
 

--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -609,16 +609,24 @@ class Controller(threading.Thread):
         # ticks instead of a single PURGE BINARY LOGS covering the whole backlog (which holds LOCK_index, stalling
         # all writes, for the entire duration). binlogs_to_purge is a contiguous oldest-first prefix and any
         # shorter prefix is equally safe to purge, so we simply truncate it to satisfy whichever cap is hit first.
-        binlogs_to_purge = cls._cap_binlogs_to_purge(binlogs_to_purge, purge_settings=purge_settings, log=log)
-        return binlogs_to_purge, bool(only_binlogs_without_gtids or only_binlogs_that_are_too_new)
+        binlogs_to_purge, more_purgeable_remaining = cls._cap_binlogs_to_purge(
+            binlogs_to_purge, purge_settings=purge_settings, log=log
+        )
+        return (
+            binlogs_to_purge,
+            bool(only_binlogs_without_gtids or only_binlogs_that_are_too_new),
+            more_purgeable_remaining,
+        )
 
     @staticmethod
     def _cap_binlogs_to_purge(binlogs_to_purge, *, purge_settings, log):
         """Trim a contiguous oldest-first list of purgeable binlogs to the per-cycle caps.
 
-        Returns the longest prefix that satisfies both max_files_per_cycle and max_bytes_per_cycle. At least one
-        binlog is always kept (even if it alone exceeds max_bytes_per_cycle) so that purging always makes forward
-        progress. A cap that is None, absent or non-positive means unbounded for that dimension.
+        Returns a ``(capped, was_capped)`` tuple where ``capped`` is the longest prefix that satisfies both
+        max_files_per_cycle and max_bytes_per_cycle and ``was_capped`` indicates whether anything was trimmed
+        (i.e. a safe backlog still remains after this cycle). At least one binlog is always kept (even if it alone
+        exceeds max_bytes_per_cycle) so that purging always makes forward progress. A cap that is None, absent or
+        non-positive means unbounded for that dimension.
         """
         max_files = purge_settings.get("max_files_per_cycle")
         max_bytes = purge_settings.get("max_bytes_per_cycle")
@@ -630,7 +638,7 @@ class Controller(threading.Thread):
         if max_bytes is not None and max_bytes <= 0:
             max_bytes = None
         if (max_files is None and max_bytes is None) or not binlogs_to_purge:
-            return binlogs_to_purge
+            return binlogs_to_purge, False
 
         capped = []
         total_bytes = 0
@@ -643,7 +651,8 @@ class Controller(threading.Thread):
             capped.append(binlog)
             total_bytes += binlog_size
 
-        if len(capped) < len(binlogs_to_purge):
+        was_capped = len(capped) < len(binlogs_to_purge)
+        if was_capped:
             log.info(
                 "Capping per-cycle purge to %s/%s binlogs (%s bytes); max_files_per_cycle=%s max_bytes_per_cycle=%s",
                 len(capped),
@@ -652,7 +661,7 @@ class Controller(threading.Thread):
                 max_files,
                 max_bytes,
             )
-        return capped
+        return capped, was_capped
 
     @staticmethod
     def get_backup_list(backup_sites: Dict[str, BackupSiteInfo], *, seen_basebackup_infos=None, site_transfers=None):
@@ -1626,6 +1635,23 @@ class Controller(threading.Thread):
                 owned_stream_ids = [sid for sid in self.state["owned_stream_ids"] if sid != backup["stream_id"]]
                 self.state_manager.update_state(owned_stream_ids=owned_stream_ids)
 
+    @staticmethod
+    def _next_binlogs_purged_at(*, now, purge_settings, fast_follow_up):
+        """Compute the ``binlogs_purged_at`` timestamp to store at the end of a purge cycle.
+
+        The purge interval gate (top of ``_purge_old_binlogs``) opens when ``now - binlogs_purged_at >=
+        purge_interval``. Returning ``now`` gives the normal one-cycle-per-``purge_interval`` cadence. When
+        ``fast_follow_up`` is set (a chunk was purged and more safely-purgeable binlogs remain) we rewind past the
+        whole interval so the gate is already open on the next control-loop tick and the backlog keeps draining a
+        chunk per tick instead of a chunk per ``purge_interval``.
+
+        Expressed purely via ``binlogs_purged_at`` (which the gate reads), so the shared run-loop sleep is never
+        altered and no drain state has to be tracked across calls.
+        """
+        if not fast_follow_up:
+            return now
+        return now - purge_settings["purge_interval"]
+
     def _purge_old_binlogs(self, *, mysql_maybe_not_running=False):
         purge_settings = self.binlog_purge_settings
         if not purge_settings["enabled"] or time.time() - self.state["binlogs_purged_at"] < purge_settings["purge_interval"]:
@@ -1655,6 +1681,12 @@ class Controller(threading.Thread):
         # This is reported in another metric to indicate time since we could've purged binlogs but didn't because
         # there was not sufficient info to make a decision (due to system being idle and no changes happening)
         last_could_have_purged = self.state["last_could_have_purged"]
+        # more_purgeable_remaining is set at collection time when the per-cycle caps trimmed the eligible set, i.e.
+        # more safely-purgeable binlogs remain for a follow-up chunk. purged_chunk records whether we actually ran a
+        # PURGE this cycle; both must be true to schedule a fast follow-up (see the finally block), so a PURGE that
+        # early-returns on error does not turn the once-per-interval retry into a tight retry loop.
+        more_purgeable_remaining = False
+        purged_chunk = False
         try:
             should_purge = self._should_purge_binlogs(
                 backup_streams=backup_streams,
@@ -1669,7 +1701,7 @@ class Controller(threading.Thread):
                     last_could_have_purged = time.time()
                 return
 
-            binlogs_to_purge, only_inapplicable_binlogs = self.collect_binlogs_to_purge(
+            binlogs_to_purge, only_inapplicable_binlogs, more_purgeable_remaining = self.collect_binlogs_to_purge(
                 backup_streams=backup_streams,
                 binlogs=binlogs,
                 exclude_uuid=exclude_uuid,
@@ -1704,6 +1736,7 @@ class Controller(threading.Thread):
                         self.log.warning("Cannot purge binary logs while a backup lock is held: %r", ex)
                         return
                     raise
+                purged_chunk = True
                 last_purge = time.time()
                 last_could_have_purged = last_purge
                 # Report the per-cycle purge batch size so we can verify the per-cycle caps are engaging in
@@ -1723,8 +1756,20 @@ class Controller(threading.Thread):
         finally:
             current_time = time.time()
 
+            # Decide when the next purge cycle may run. Normally the interval gate allows one cycle per
+            # purge_interval; when we just purged a capped chunk and more safely-purgeable binlogs remain we rewind
+            # binlogs_purged_at past the interval so the gate is already open on the next control-loop tick and the
+            # backlog drains a chunk per tick instead of one chunk per purge_interval. Scheduling is expressed purely
+            # via binlogs_purged_at (which the gate reads), so the shared run-loop cadence (_get_iteration_sleep) is
+            # untouched and other controller work is never paced by the drain.
+            binlogs_purged_at = self._next_binlogs_purged_at(
+                now=current_time,
+                purge_settings=purge_settings,
+                fast_follow_up=more_purgeable_remaining and purged_chunk,
+            )
+
             self.state_manager.update_state(
-                binlogs_purged_at=current_time,
+                binlogs_purged_at=binlogs_purged_at,
                 last_binlog_purge=last_purge,
                 last_could_have_purged=last_could_have_purged,
             )

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -5,7 +5,7 @@ from . import build_controller, DataGenerator, get_mysql_config_options, MySQLCo
 from .helpers.version import xtrabackup_version_to_string
 from myhoard.backup_stream import BackupStream
 from myhoard.basebackup_restore_operation import BasebackupRestoreOperation
-from myhoard.controller import Backup, BaseBackup, Controller, sort_completed_backups
+from myhoard.controller import Backup, BaseBackup, Controller, ERR_BACKUP_IN_PROGRESS, sort_completed_backups
 from myhoard.restore_coordinator import RestoreCoordinator
 from myhoard.util import (
     change_replication_source_to,
@@ -18,12 +18,14 @@ from myhoard.util import (
     partition_sort_and_combine_gtid_ranges,
 )
 from rohmu import get_transfer
+from types import SimpleNamespace
 from typing import Any, Callable, cast, Dict, List, Optional, Set, TypedDict
 from unittest.mock import call, MagicMock, patch
 
 import contextlib
 import datetime
 import os
+import pymysql
 import pytest
 import random
 import re
@@ -1360,7 +1362,7 @@ def test_collect_binlogs_to_purge():
     }
     log = MagicMock()
 
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=None,
         binlogs=binlogs,
         log=log,
@@ -1379,7 +1381,7 @@ def test_collect_binlogs_to_purge():
     bs1.is_binlog_safe_to_delete.return_value = False
     bs2 = MagicMock()
     bs2.is_binlog_safe_to_delete.return_value = True
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=[bs1, bs2],
         binlogs=binlogs,
         log=log,
@@ -1391,7 +1393,7 @@ def test_collect_binlogs_to_purge():
     assert only_inapplicable_binlogs is False
     log.info.assert_called_with("Binlog %s reported not safe to delete by some backup streams", 1)
 
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=[bs1, bs2],
         binlogs=binlogs,
         log=log,
@@ -1410,7 +1412,7 @@ def test_collect_binlogs_to_purge():
 
     # No backup streams or replication state and observe node, should allow purging anything
     log = MagicMock()
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=[],
         binlogs=binlogs,
         log=log,
@@ -1430,7 +1432,7 @@ def test_collect_binlogs_to_purge():
         "server1": {},
     }
     bs1.is_binlog_safe_to_delete.return_value = True
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=[bs1, bs2],
         binlogs=binlogs,
         log=log,
@@ -1446,7 +1448,7 @@ def test_collect_binlogs_to_purge():
     replication_state = {
         "server1": {"uuid1": [[1, 7]]},
     }
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=[bs1, bs2],
         binlogs=binlogs,
         log=log,
@@ -1463,7 +1465,7 @@ def test_collect_binlogs_to_purge():
     replication_state = {
         "server1": {"uuid1": [[1, 8]]},
     }
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=[bs1, bs2],
         binlogs=binlogs,
         log=log,
@@ -1479,7 +1481,7 @@ def test_collect_binlogs_to_purge():
     log = MagicMock()
     binlogs[0]["gtid_ranges"] = []
     binlogs[1]["gtid_ranges"] = []
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=[bs1, bs2],
         binlogs=binlogs,
         log=log,
@@ -1498,7 +1500,7 @@ def test_collect_binlogs_to_purge():
         }
     )
     log = MagicMock()
-    binlogs_to_purge, only_inapplicable_binlogs = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, only_inapplicable_binlogs, _ = Controller.collect_binlogs_to_purge(
         backup_streams=[bs1, bs2],
         binlogs=binlogs,
         log=log,
@@ -1544,23 +1546,27 @@ def _collect_all_eligible(binlogs, purge_settings):
 def test_collect_binlogs_to_purge_caps_by_file_count():
     binlogs = _make_purgeable_binlogs(10, file_size=1)
     purge_settings = {"min_binlog_age_before_purge": 5, "max_files_per_cycle": 3, "max_bytes_per_cycle": None}
-    binlogs_to_purge, only_inapplicable_binlogs = _collect_all_eligible(binlogs, purge_settings)
+    binlogs_to_purge, only_inapplicable_binlogs, more_purgeable_remaining = _collect_all_eligible(binlogs, purge_settings)
     # Exactly the oldest 3 files, contiguous from the oldest end.
     assert binlogs_to_purge == binlogs[:3]
     assert only_inapplicable_binlogs is False
+    # More safely-purgeable binlogs remain, so the caller should drain them without waiting a full interval.
+    assert more_purgeable_remaining is True
 
 
 def test_collect_binlogs_to_purge_caps_by_bytes():
     binlogs = _make_purgeable_binlogs(10, file_size=100)
     # 250 bytes fits 2 full files (200) but not a 3rd (300 > 250).
     purge_settings = {"min_binlog_age_before_purge": 5, "max_files_per_cycle": None, "max_bytes_per_cycle": 250}
-    binlogs_to_purge, _ = _collect_all_eligible(binlogs, purge_settings)
+    binlogs_to_purge, _, more_purgeable_remaining = _collect_all_eligible(binlogs, purge_settings)
     assert binlogs_to_purge == binlogs[:2]
+    assert more_purgeable_remaining is True
 
     # A single file larger than the byte cap is still purged so we always make forward progress.
     purge_settings["max_bytes_per_cycle"] = 10
-    binlogs_to_purge, _ = _collect_all_eligible(binlogs, purge_settings)
+    binlogs_to_purge, _, more_purgeable_remaining = _collect_all_eligible(binlogs, purge_settings)
     assert binlogs_to_purge == binlogs[:1]
+    assert more_purgeable_remaining is True
 
 
 def test_collect_binlogs_to_purge_caps_with_no_gtid_tail():
@@ -1589,7 +1595,7 @@ def test_collect_binlogs_to_purge_caps_with_no_gtid_tail():
     bs.is_binlog_safe_to_delete.return_value = True
     replication_state = {"server1": {"uuid1": [[1, 2]]}}
     purge_settings = {"min_binlog_age_before_purge": 5, "max_files_per_cycle": 2, "max_bytes_per_cycle": None}
-    binlogs_to_purge, _ = Controller.collect_binlogs_to_purge(
+    binlogs_to_purge, _, more_purgeable_remaining = Controller.collect_binlogs_to_purge(
         backup_streams=[bs],
         binlogs=binlogs,
         log=MagicMock(),
@@ -1599,28 +1605,32 @@ def test_collect_binlogs_to_purge_caps_with_no_gtid_tail():
     )
     # The two leading no-GTID files are flushed when binlog 3 is confirmed replicated; the cap keeps the oldest 2.
     assert binlogs_to_purge == binlogs[:2]
+    assert more_purgeable_remaining is True
 
 
 def test_collect_binlogs_to_purge_no_change_below_caps():
     binlogs = _make_purgeable_binlogs(5, file_size=100)
-    uncapped, uncapped_inapplicable = _collect_all_eligible(
+    uncapped, uncapped_inapplicable, uncapped_more_remaining = _collect_all_eligible(
         binlogs, {"min_binlog_age_before_purge": 5, "max_files_per_cycle": None, "max_bytes_per_cycle": None}
     )
-    capped, capped_inapplicable = _collect_all_eligible(
+    capped, capped_inapplicable, capped_more_remaining = _collect_all_eligible(
         binlogs, {"min_binlog_age_before_purge": 5, "max_files_per_cycle": 50, "max_bytes_per_cycle": 5 << 30}
     )
     assert uncapped == binlogs
     assert capped == uncapped
     assert capped_inapplicable == uncapped_inapplicable
+    # The eligible set is below both caps, so nothing was trimmed and no follow-up cycle is needed.
+    assert uncapped_more_remaining is False
+    assert capped_more_remaining is False
 
 
 def test_cap_binlogs_to_purge_passthrough_when_unset():
     cap = Controller._cap_binlogs_to_purge  # pylint: disable=protected-access
     binlogs = _make_purgeable_binlogs(5, file_size=100)
-    # No caps configured at all -> the list is returned unchanged.
-    assert cap(binlogs, purge_settings={}, log=MagicMock()) == binlogs
+    # No caps configured at all -> the list is returned unchanged and nothing remains for a follow-up cycle.
+    assert cap(binlogs, purge_settings={}, log=MagicMock()) == (binlogs, False)
     # Empty input is returned unchanged regardless of caps.
-    assert not cap([], purge_settings={"max_files_per_cycle": 1}, log=MagicMock())
+    assert cap([], purge_settings={"max_files_per_cycle": 1}, log=MagicMock()) == ([], False)
 
 
 def test_cap_binlogs_to_purge_non_positive_caps_mean_unbounded():
@@ -1634,7 +1644,76 @@ def test_cap_binlogs_to_purge_non_positive_caps_mean_unbounded():
         {"max_files_per_cycle": 0, "max_bytes_per_cycle": None},
         {"max_files_per_cycle": None, "max_bytes_per_cycle": 0},
     ):
-        assert cap(binlogs, purge_settings=settings, log=MagicMock()) == binlogs
+        assert cap(binlogs, purge_settings=settings, log=MagicMock()) == (binlogs, False)
+
+
+def test_next_binlogs_purged_at():
+    # pylint: disable=protected-access
+    schedule = Controller._next_binlogs_purged_at
+    now = 1000.0
+    settings = {"purge_interval": 60}
+
+    # No fast follow-up (nothing capped, or nothing purged): normal cadence, gate stays closed for a full interval.
+    assert schedule(now=now, purge_settings=settings, fast_follow_up=False) == now
+
+    # Fast follow-up: rewind past the whole interval so the gate is already open on the next control-loop tick.
+    assert schedule(now=now, purge_settings=settings, fast_follow_up=True) == now - 60
+
+
+def _run_purge_old_binlogs(*, capped_more_remaining, purge_raises=None):
+    # Drive _purge_old_binlogs against a lightweight stub so the finally-block scheduling contract can be tested
+    # without a running MySQL. Only the attributes _purge_old_binlogs touches are provided; the real
+    # _next_binlogs_purged_at is bound so we exercise the actual scheduling decision.
+    purge_settings = {
+        "enabled": True,
+        "min_binlog_age_before_purge": 30,
+        "purge_interval": 60,
+        "purge_when_observe_no_streams": True,
+    }
+    binlog = {"file_name": "binlog.000001", "file_size": 1}
+    stub = SimpleNamespace(
+        binlog_purge_settings=purge_settings,
+        state={"binlogs_purged_at": 0, "last_binlog_purge": 0, "last_could_have_purged": 0, "replication_state": {}},
+        binlog_scanner=SimpleNamespace(binlogs=[binlog]),
+        backup_streams=[MagicMock()],
+        mode=Controller.Mode.active,
+        Mode=Controller.Mode,
+        log=MagicMock(),
+        stats=MagicMock(),
+        state_manager=MagicMock(),
+        _should_purge_binlogs=MagicMock(return_value=True),
+        collect_binlogs_to_purge=MagicMock(return_value=([binlog], False, capped_more_remaining)),
+        _get_long_timeout_params=MagicMock(return_value={}),
+        _next_binlogs_purged_at=Controller._next_binlogs_purged_at,  # pylint: disable=protected-access
+    )
+
+    cursor_cm = MagicMock()
+    if purge_raises is not None:
+        cursor_cm.__enter__.return_value.execute.side_effect = pymysql.err.OperationalError(purge_raises, "boom")
+
+    with patch("myhoard.controller.mysql_cursor", return_value=cursor_cm):
+        Controller._purge_old_binlogs(stub)  # pylint: disable=protected-access
+    return stub
+
+
+def test_purge_old_binlogs_schedules_fast_follow_up_only_on_successful_capped_chunk():
+    # Successful purge with more capped binlogs remaining -> rewind binlogs_purged_at so the gate is open next tick.
+    stub = _run_purge_old_binlogs(capped_more_remaining=True)
+    saved = stub.state_manager.update_state.call_args.kwargs["binlogs_purged_at"]
+    assert saved < time.time() - 30  # rewound roughly a full purge_interval into the past
+
+    # Successful purge but nothing capped -> normal cadence, no rewind.
+    stub = _run_purge_old_binlogs(capped_more_remaining=False)
+    saved = stub.state_manager.update_state.call_args.kwargs["binlogs_purged_at"]
+    assert saved >= time.time() - 5
+
+
+def test_purge_old_binlogs_does_not_fast_retry_when_purge_fails():
+    # PURGE fails (e.g. a backup holds the lock) even though the cap says more remain: we must NOT rewind,
+    # otherwise the once-per-interval retry becomes a tight retry loop while the lock is held.
+    stub = _run_purge_old_binlogs(capped_more_remaining=True, purge_raises=ERR_BACKUP_IN_PROGRESS)
+    saved = stub.state_manager.update_state.call_args.kwargs["binlogs_purged_at"]
+    assert saved >= time.time() - 5  # normal cadence, not rewound
 
 
 def test_periodic_backup_based_on_exceeded_intervals(time_machine, master_controller) -> None:


### PR DESCRIPTION
The per-cycle caps keep each PURGE small, but purging only runs once per
purge_interval (60s), so a big backlog cleared just one chunk a minute — 
hours or days for a large one.

Now, when a capped chunk leaves more to purge, we let the next chunk run on
the following control-loop tick (~1s) instead of waiting a full interval. The
backlog drains steadily while each PURGE still holds LOCK_index only briefly,
and the ~1s gap gives ordinary transactions room to commit in between. We only
speed up after a chunk actually purged, so a failed PURGE just retries at the
normal pace.