### PR TITLE
Expose restored backup and chain position in /status/restore

### DIFF
--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -37,7 +37,7 @@ from functools import partial
 from pymysql import OperationalError
 from rohmu import errors as rohmu_errors
 from rohmu.transfer_pool import TransferPool
-from typing import Any, Dict, Iterable, List, Optional, Tuple, TypedDict
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, TypedDict
 
 import contextlib
 import enum
@@ -71,6 +71,19 @@ class PendingBinlogInfo(TypedDict):
 class BinlogStream(TypedDict):
     site: str
     stream_id: str
+
+
+class RestoreChainProgress(NamedTuple):
+    """Which basebackup in an incremental chain is currently being restored.
+
+    ``chain_index``/``chain_total`` are 1-based (e.g. "incremental 3 of 7"); for
+    a plain non-incremental restore the chain collapses to ``1 of 1``.
+    """
+
+    current_backup_name: str
+    current_backup_incremental: bool
+    chain_index: int
+    chain_total: int
 
 
 class RestoreCoordinator(threading.Thread):
@@ -322,6 +335,36 @@ class RestoreCoordinator(threading.Thread):
     @property
     def binlogs_restored(self) -> int:
         return self.state["binlogs_restored"]
+
+    @property
+    def restore_chain_progress(self) -> RestoreChainProgress:
+        """Identify which basebackup in the chain is currently being restored.
+
+        ``required_backups`` holds the prerequisite streams (the full backup followed by
+        any earlier incrementals); the restore target ``self.stream_id`` is applied last,
+        so the full chain length is ``len(required_backups) + 1``. ``required_backups`` is
+        populated during the ``getting_backup_info`` phase, so this is only meaningful once
+        the basebackup phases are reached; before then it reports ``1 of 1``.
+        """
+        required_backups = self.state.get("required_backups") or []
+        total = len(required_backups) + 1
+        restored = self.state["required_backups_restored"]
+        if restored < len(required_backups):
+            # Still working through the prerequisite backups. Items are stored as
+            # (stream_id, info) pairs (lists after a state-file round-trip).
+            stream_id, info = required_backups[restored]
+            return RestoreChainProgress(
+                current_backup_name=stream_id,
+                current_backup_incremental=bool(info.get("incremental", False)),
+                chain_index=restored + 1,
+                chain_total=total,
+            )
+        return RestoreChainProgress(
+            current_backup_name=self.stream_id,
+            current_backup_incremental=bool(self.state["basebackup_info"].get("incremental", False)),
+            chain_index=total,
+            chain_total=total,
+        )
 
     def can_add_binlog_streams(self):
         # If we're restoring to a specific backup then we don't want to look for possible new backup

--- a/myhoard/web_server.py
+++ b/myhoard/web_server.py
@@ -215,6 +215,7 @@ class WebServer:
                     if coordinator.phase == RestoreCoordinator.Phase.preparing_backup
                     else None
                 )
+                chain = coordinator.restore_chain_progress
                 response = {
                     "basebackup_compressed_bytes_downloaded": coordinator.basebackup_bytes_downloaded,
                     "basebackup_compressed_bytes_total": coordinator.basebackup_bytes_total,
@@ -223,6 +224,10 @@ class WebServer:
                     "binlogs_restored": coordinator.binlogs_restored,
                     "phase": coordinator.phase,
                     "basebackup_prepare_progress": prepare_progress,
+                    "current_backup_name": chain.current_backup_name,
+                    "current_backup_incremental": chain.current_backup_incremental,
+                    "restore_chain_index": chain.chain_index,
+                    "restore_chain_total": chain.chain_total,
                 }
             return json_response(response)
 

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -680,7 +680,7 @@ def test_basebackup_bytes_total(
     assert rc.basebackup_bytes_total == expected_bytes_total
 
 
-def _make_minimal_coordinator(session_tmpdir):
+def _make_minimal_coordinator(session_tmpdir, stream_id: str = "-"):
     return RestoreCoordinator(
         binlog_streams=[],
         download_workers_count=2,
@@ -698,9 +698,41 @@ def _make_minimal_coordinator(session_tmpdir):
         site="default",
         state_file=os.path.join(session_tmpdir().strpath, "the_state_file.json"),
         stats=build_statsd_client(),
-        stream_id="-",
+        stream_id=stream_id,
         temp_dir=session_tmpdir().strpath,
     )
+
+
+@pytest.mark.parametrize(
+    "stream_id,basebackup_info,required_backups,required_backups_restored,expected",
+    [
+        # Plain (non-incremental) restore: no prerequisite backups, collapses to 1 of 1.
+        ("full", {}, [], 0, ("full", False, 1, 1)),
+        ("full", {"incremental": False}, [], 0, ("full", False, 1, 1)),
+        # Incremental target "inc2" needs full + inc1 restored first (chain of 3).
+        # Prerequisites are worked through in order; required_backups_restored counts
+        # how many have completed, so it points at the backup currently being applied.
+        ("inc2", {"incremental": True}, [("full", {}), ("inc1", {"incremental": True})], 0, ("full", False, 1, 3)),
+        ("inc2", {"incremental": True}, [("full", {}), ("inc1", {"incremental": True})], 1, ("inc1", True, 2, 3)),
+        # All prerequisites done -> now applying the target itself, at the tail of the chain.
+        ("inc2", {"incremental": True}, [("full", {}), ("inc1", {"incremental": True})], 2, ("inc2", True, 3, 3)),
+    ],
+)
+def test_restore_chain_progress(
+    session_tmpdir,
+    stream_id: str,
+    basebackup_info: dict[str, Any],
+    required_backups: list[tuple[str, dict[str, Any]]],
+    required_backups_restored: int,
+    expected: tuple[str, bool, int, int],
+) -> None:
+    rc = _make_minimal_coordinator(session_tmpdir, stream_id=stream_id)
+    rc.update_state(
+        basebackup_info=basebackup_info,
+        required_backups=required_backups,
+        required_backups_restored=required_backups_restored,
+    )
+    assert tuple(rc.restore_chain_progress) == expected
 
 
 def test_on_prepare_progress_flips_phase_and_persists_pct(session_tmpdir):

--- a/test/test_web_server.py
+++ b/test/test_web_server.py
@@ -168,6 +168,10 @@ async def test_status_update_to_restore(master_controller, web_client):
         # Operation will fail because we faked the backup info
         assert response["phase"] != RestoreCoordinator.Phase.failed
         assert "basebackup_prepare_progress" in response
+        assert response["current_backup_name"] == "abc"
+        assert isinstance(response["current_backup_incremental"], bool)
+        assert response["restore_chain_index"] == 1
+        assert response["restore_chain_total"] == 1
 
     master_controller[0].state["backups"].append(
         {"stream_id": "abc", "site": "default", "basebackup_info": {"end_ts": 1234567}}


### PR DESCRIPTION
During an incremental restore /status/restore reported only the phase and
byte/binlog counters, so neither operators nor customers could tell which
backup in the chain was being applied or how many remained. In INC-1429 a
broken chain was retried repeatedly with no easy way to see where the restore
was, forcing correlation of ~30s status logs against a pre-restore backup
listing.

RestoreCoordinator already tracks everything needed (required_backups, the
prerequisite full + earlier incrementals; required_backups_restored; and the
target stream_id applied last), it was just never surfaced. Add a
restore_chain_progress property that reports the current backup name, whether
it is incremental, and a 1-based index/total (chain length is
len(required_backups) + 1), and include those four fields in the
/status/restore response. A plain non-incremental restore collapses to 1 of 1.

This is the myhoard half of surfacing chain position; the management plane,
Ops CLI and Console consume these fields separately.

[MYC-174]

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
