### PR TITLE
Keep the event scheduler off while restoring a backup

### DIFF
--- a/myhoard/myhoard.py
+++ b/myhoard/myhoard.py
@@ -7,6 +7,7 @@ from myhoard.util import (
     detect_running_process_id,
     find_extra_xtrabackup_executables,
     parse_dow_schedule,
+    restore_mysqld_options,
     wait_for_port,
 )
 from myhoard.web_server import WebServer
@@ -154,14 +155,7 @@ class MyHoard:
         if systemd_service:
             self._restart_systemd(with_binlog=with_binlog, with_gtids=with_gtids, service=systemd_service)
         else:
-            mysqld_options = []
-            if not with_binlog:
-                mysqld_options.append("--disable-log-bin")
-                # If config says slave-preserve-commit-order=ON MySQL would refuse to start if binlog is
-                # disabled. To prevent that from happening ensure preserve commit order is disabled
-                mysqld_options.append("--skip-slave-preserve-commit-order")
-            if not with_gtids:
-                mysqld_options.append("--gtid-mode=OFF")
+            mysqld_options = restore_mysqld_options(with_binlog=with_binlog, with_gtids=with_gtids)
             self._restart_process(mysqld_options=mysqld_options)
 
         # Ensure the server is accepting connections

--- a/myhoard/update_mysql_environment.py
+++ b/myhoard/update_mysql_environment.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2019 Aiven, Helsinki, Finland. https://aiven.io/
-from myhoard.util import atomic_create_file
+from myhoard.util import atomic_create_file, restore_mysqld_options
 
 import argparse
 import logging
@@ -17,14 +17,9 @@ class EnvironmentUpdater:
     def update(self):
         # make sure we only update the parameter we need to update i.e., MYSQLD_OPTS
         key = "MYSQLD_OPTS"  # we only update this environment variable
-        options = []
-        if self.args.with_bin_log != "true":
-            options.append("--disable-log-bin")
-            # If config says slave-preserve-commit-order=ON MySQL would refuse to start if binlog is
-            # disabled. To prevent that from happening ensure preserve commit order is disabled
-            options.append("--skip-slave-preserve-commit-order")
-        if self.args.gtid_mode != "true":
-            options.append("--gtid-mode=OFF")
+        options = restore_mysqld_options(
+            with_binlog=self.args.with_bin_log == "true", with_gtids=self.args.gtid_mode == "true"
+        )
         try:
             with open(self.args.env_file, "r") as f:
                 contents = [line.rstrip("\n") for line in f.readlines() if line.strip() and not line.startswith(key)]

--- a/myhoard/util.py
+++ b/myhoard/util.py
@@ -515,6 +515,25 @@ def detect_running_process_id(command: str) -> Tuple[Optional[int], bytes]:
     return ids[0], output_bytes
 
 
+def restore_mysqld_options(*, with_binlog: bool, with_gtids: bool) -> list[str]:
+    """Extra mysqld command line options for a server start that is part of a restore"""
+    options = []
+    if not with_binlog:
+        options.append("--disable-log-bin")
+        # If config says slave-preserve-commit-order=ON MySQL would refuse to start if binlog is
+        # disabled. To prevent that from happening ensure preserve commit order is disabled
+        options.append("--skip-slave-preserve-commit-order")
+        # Only restore phases run with the binlog disabled. A physical basebackup keeps events in
+        # ENABLED state and every restored event whose schedule lapsed during the restore fires
+        # within seconds of startup, so their writes race the transactions being replayed from the
+        # binlogs and the applier dies on a duplicate key. This has to be a startup option: by the
+        # time we could connect and SET GLOBAL, the events have already fired.
+        options.append("--event-scheduler=OFF")
+    if not with_gtids:
+        options.append("--gtid-mode=OFF")
+    return options
+
+
 def wait_for_port(*, host, port, timeout):
     """Waits until given (address, port) tuple starts listening or given timeout is exceeded"""
     start_time = time.monotonic()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -191,8 +191,11 @@ def restart_mysql(mysql_config, *, with_binlog=True, with_gtids=True):
         proc.wait(timeout=20.0)
         print("Stopped mysqld with pid", proc.pid)
     command = mysql_config.startup_command
+    # Deliberately not myhoard.util.restore_mysqld_options: that one spells the option the 8.0 way
+    # as --skip-slave-preserve-commit-order, while the tests also run against 8.4. Keep the rest of
+    # the list in sync with it.
     if not with_binlog:
-        command = command + ["--disable-log-bin", "--skip-replica-preserve-commit-order"]
+        command = command + ["--disable-log-bin", "--skip-replica-preserve-commit-order", "--event-scheduler=OFF"]
     if not with_gtids:
         command = command + ["--gtid-mode=OFF"]
     mysql_config.proc = subprocess.Popen(command)  # pylint: disable=consider-using-with

--- a/test/test_restore_coordinator.py
+++ b/test/test_restore_coordinator.py
@@ -299,6 +299,17 @@ def _restore_coordinator_sequence(
         "user": mysql_master.user,
     }
     state_file_name = os.path.join(session_tmpdir().strpath, "restore_coordinator.json")
+
+    # Record what the event scheduler was actually set to by each restart the restore performs
+    scheduler_states: list[tuple[bool, str]] = []
+
+    def restart_mysql_and_record_scheduler(**kwargs):
+        restart_mysql(mysql_empty, **kwargs)
+        with myhoard_util.mysql_cursor(**restored_connect_options) as cursor:
+            cursor.execute("SELECT @@GLOBAL.event_scheduler AS event_scheduler")
+            scheduler = cast(dict, cursor.fetchone())["event_scheduler"]
+        scheduler_states.append((kwargs["with_binlog"], scheduler))
+
     # Restore basebackup from backup stream 1 but binlogs from both streams. First stream doesn't
     # contain latest state but applying binlogs from second stream should get it fully up-to-date
     rc = RestoreCoordinator(
@@ -319,7 +330,7 @@ def _restore_coordinator_sequence(
         mysql_relay_log_prefix=mysql_empty.config_options.relay_log_file_prefix,
         pending_binlogs_state_file=state_file_name.replace(".json", "") + ".pending_binlogs",
         rebuild_tables=rebuild_tables,
-        restart_mysqld_callback=lambda **kwargs: restart_mysql(mysql_empty, **kwargs),
+        restart_mysqld_callback=restart_mysql_and_record_scheduler,
         rsa_private_key_pem=private_key_pem,
         site="default",
         state_file=state_file_name,
@@ -349,6 +360,14 @@ def _restore_coordinator_sequence(
     assert len(rc.state["backup_xtrabackup_version"]) >= 3
     assert get_xtrabackup_version() == rc.state["backup_xtrabackup_version"]
     assert rc.should_mark_backup_as_broken() is False
+
+    # A basebackup keeps events in ENABLED state, so any restore-phase server start must keep the event
+    # scheduler off: the events would otherwise fire immediately and write rows that collide with the
+    # transactions still being replayed from the binlogs. The restart that finalizes the restore passes
+    # no options at all, so the scheduler is back on for the restored server.
+    assert (False, "OFF") in scheduler_states
+    assert all(scheduler == "OFF" for with_binlog, scheduler in scheduler_states if not with_binlog)
+    assert scheduler_states[-1] == (True, "ON")
 
     if fail_and_resume:
         assert isinstance(rc.state_manager, FailingStateManager)

--- a/test/test_update_mysql_environment.py
+++ b/test/test_update_mysql_environment.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Aiven, Helsinki, Finland. https://aiven.io/
+from myhoard.update_mysql_environment import EnvironmentUpdater
+from pathlib import Path
+
+import argparse
+import pytest
+
+pytestmark = [pytest.mark.unittest, pytest.mark.all]
+
+
+def update_environment(env_file: Path, *, with_bin_log: str, gtid_mode: str) -> list[str]:
+    """Run the updater the way sudo does and return the variables it left in the file"""
+    args = argparse.Namespace(env_file=str(env_file), with_bin_log=with_bin_log, gtid_mode=gtid_mode)
+    EnvironmentUpdater(args).update()
+    # An empty variable list leaves the file holding just a newline
+    return [line for line in env_file.read_text().splitlines() if line]
+
+
+@pytest.mark.parametrize(
+    "with_bin_log,gtid_mode,expected",
+    [
+        (
+            "false",
+            "false",
+            "MYSQLD_OPTS=--disable-log-bin --skip-slave-preserve-commit-order --event-scheduler=OFF --gtid-mode=OFF",
+        ),
+        ("false", "true", "MYSQLD_OPTS=--disable-log-bin --skip-slave-preserve-commit-order --event-scheduler=OFF"),
+        ("true", "false", "MYSQLD_OPTS=--gtid-mode=OFF"),
+    ],
+)
+def test_restore_phase_options_are_written(tmp_path: Path, with_bin_log: str, gtid_mode: str, expected: str) -> None:
+    env_file = tmp_path / "mysqld.environment"
+
+    lines = update_environment(env_file, with_bin_log=with_bin_log, gtid_mode=gtid_mode)
+
+    assert lines == [expected]
+
+
+def test_finalizing_a_restore_drops_the_variable(tmp_path: Path) -> None:
+    # Removing MYSQLD_OPTS entirely is how mysqld gets back to the my.cnf settings once the restore is
+    # done, most importantly with the event scheduler enabled again.
+    env_file = tmp_path / "mysqld.environment"
+    update_environment(env_file, with_bin_log="false", gtid_mode="true")
+
+    lines = update_environment(env_file, with_bin_log="true", gtid_mode="true")
+
+    assert lines == []
+
+
+def test_unrelated_variables_are_preserved(tmp_path: Path) -> None:
+    env_file = tmp_path / "mysqld.environment"
+    env_file.write_text("SOME_OTHER_VAR=value\nMYSQLD_OPTS=--stale-option\n")
+
+    lines = update_environment(env_file, with_bin_log="false", gtid_mode="true")
+
+    assert lines == [
+        "SOME_OTHER_VAR=value",
+        "MYSQLD_OPTS=--disable-log-bin --skip-slave-preserve-commit-order --event-scheduler=OFF",
+    ]

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -424,6 +424,25 @@ def test_find_extra_xtrabackup_executables() -> None:
 
 
 @pytest.mark.parametrize(
+    "with_binlog,with_gtids,expected",
+    [
+        (
+            False,
+            False,
+            ["--disable-log-bin", "--skip-slave-preserve-commit-order", "--event-scheduler=OFF", "--gtid-mode=OFF"],
+        ),
+        (False, True, ["--disable-log-bin", "--skip-slave-preserve-commit-order", "--event-scheduler=OFF"]),
+        (True, False, ["--gtid-mode=OFF"]),
+        # The restart that finalizes a restore. It must produce no options at all so that mysqld goes
+        # back to whatever my.cnf says, in particular so the event scheduler is enabled again.
+        (True, True, []),
+    ],
+)
+def test_restore_mysqld_options(with_binlog: bool, with_gtids: bool, expected: list[str]) -> None:
+    assert myhoard_util.restore_mysqld_options(with_binlog=with_binlog, with_gtids=with_gtids) == expected
+
+
+@pytest.mark.parametrize(
     "dow_schedule,result",
     [
         ("abracadabra", ValueError),


### PR DESCRIPTION
A restore that has binary logs to apply can get stuck on a duplicate key. myhoard restarts mysqld with the binary log disabled for the restore phases but leaves event_scheduler at its default ON, and a physical basebackup keeps events in ENABLED state. Every restored event whose schedule lapsed during the restore therefore fires within seconds of startup, and the rows it writes collide with the transactions still being replayed from the binary logs. The applier stops with HA_ERR_FOUND_DUPP_KEY and retrying does not help, because the row is already there. Rebuilding the node only runs the same lottery again.

Pass --event-scheduler=OFF on the restarts that already disable the binary log. Only the restore phases run that way, so recognising them needs no new parameter, and this has to be a startup option rather than a SET GLOBAL: by the time we could connect and issue one, the events have already fired.

The restart that finalizes a restore asks for the binary log back and so produces no options at all, which drops MYSQLD_OPTS from the systemd environment file entirely. The restored server comes back with whatever its configuration file says, rather than a hardcoded ON that would override an operator who turned the scheduler off deliberately.

The two option lists that had drifted apart are now one helper, so a change like this cannot land in the subprocess path alone while production, which goes through myhoard_mysql_env_update and systemd, keeps the old behaviour. That path had no tests at all; it has some now.