### PR TITLE
fix flaky unittests

### DIFF
--- a/test/local/test_controller.py
+++ b/test/local/test_controller.py
@@ -113,6 +113,8 @@ def do_restore(
             assert all(b["broken_at"] is None for b in current_backups)
 
         else:
-            flow_tester.wait_for_restore_phase(RestoreCoordinator.Phase.completed)
+            # Basebackup restore plus binlog apply regularly takes longer than the
+            # default 10s timeout on busy CI runners.
+            flow_tester.wait_for_restore_phase(RestoreCoordinator.Phase.completed, timeout=40)
     finally:
         target_controller.stop()

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -2740,6 +2740,11 @@ def test_should_schedule_incremental_backup(
     assert m_controller._should_schedule_incremental_backup()
 
 
+# Evaluated once at collection time, so it must stay in the future for however long
+# the whole test session takes or the preserved backups become purgeable mid-run.
+PRESERVE_UNTIL = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)).isoformat()
+
+
 @pytest.mark.parametrize(
     "backups,expected_no_purge_reason,travel_to_datetime,backup_settings_extra",
     [
@@ -2825,9 +2830,7 @@ def test_should_schedule_incremental_backup(
             [
                 {
                     "stream_id": "stream1",
-                    "preserve_until": (
-                        datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=10)
-                    ).isoformat(),
+                    "preserve_until": PRESERVE_UNTIL,
                 },
                 {"stream_id": "stream2"},
                 {"stream_id": "stream3"},
@@ -2843,9 +2846,7 @@ def test_should_schedule_incremental_backup(
                 {"stream_id": "stream1"},
                 {
                     "stream_id": "stream2",
-                    "preserve_until": (
-                        datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=10)
-                    ).isoformat(),
+                    "preserve_until": PRESERVE_UNTIL,
                 },
                 {"stream_id": "stream3"},
                 {"stream_id": "stream4"},
@@ -2860,9 +2861,7 @@ def test_should_schedule_incremental_backup(
                 {"stream_id": "stream1"},
                 {
                     "stream_id": "stream2",
-                    "preserve_until": (
-                        datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=10)
-                    ).isoformat(),
+                    "preserve_until": PRESERVE_UNTIL,
                     "incremental": True,
                 },
                 {"stream_id": "stream3"},

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -9,6 +9,7 @@ from myhoard.controller import Backup, BaseBackup, Controller, ERR_BACKUP_IN_PRO
 from myhoard.restore_coordinator import RestoreCoordinator
 from myhoard.util import (
     change_replication_source_to,
+    get_replica_status,
     get_xtrabackup_version,
     GtidExecuted,
     make_fs_metadata,
@@ -300,6 +301,21 @@ def test_promoted_node_does_not_resume_streams_for_backups_initiated_by_old_mast
         # backup after the promotion process of the standby was triggered.
         with mysql_cursor(**standby1.connect_options) as cursor:
             cursor.execute("STOP REPLICA IO_THREAD")
+
+        def standby_has_applied_all_received_transactions():
+            with mysql_cursor(**standby1.connect_options) as cursor:
+                replica_status = get_replica_status(cursor)
+                assert replica_status is not None
+                cursor.execute(
+                    "SELECT GTID_SUBSET(%s, @@GLOBAL.gtid_executed) AS all_applied",
+                    [replica_status["Retrieved_Gtid_Set"]],
+                )
+                assert cursor.fetchone()["all_applied"]
+
+        # The SQL thread and its parallel workers may still be applying transactions received
+        # before the IO thread was stopped; switching to active mode is not allowed until the
+        # standby has caught up.
+        while_asserts(standby_has_applied_all_received_transactions, timeout=30)
         s1_controller.switch_to_active_mode()
 
         m_controller.mark_backup_requested(backup_reason=BackupStream.BackupReason.requested)


### PR DESCRIPTION
- **Wait for standby to apply relay log before promoting in test**
- **Keep preserved-backup timestamps valid for whole test session**
- **Give restore more time to complete in local flow test**
