### PR TITLE
Restoration switch backup when broken

### DIFF
--- a/myhoard/controller.py
+++ b/myhoard/controller.py
@@ -1354,6 +1354,8 @@ class Controller(threading.Thread):
             if self.restore_coordinator.should_mark_backup_as_broken():
                 self._mark_failed_restore_backup_as_broken()
             self._switch_basebackup_if_possible()
+        if self.restore_coordinator.phase == RestoreCoordinator.Phase.broken_basebackup:
+            self._switch_basebackup_if_possible()
         if self.state["promote_on_restore_completion"] and self.restore_coordinator.is_complete():
             self.state_manager.update_state(
                 # Ensure latest backup list is fetched before promotion so that we

--- a/myhoard/restore_coordinator.py
+++ b/myhoard/restore_coordinator.py
@@ -135,6 +135,7 @@ class RestoreCoordinator(threading.Thread):
         failed = "failed"
         # Terminal state for a RestoreCoordinator instance but restoring an earlier backup may be an option
         failed_basebackup = "failed_basebackup"
+        broken_basebackup = "broken_basebackup"
 
     class State(TypedDict):
         applying_binlogs: List[PendingBinlogInfo]
@@ -472,6 +473,16 @@ class RestoreCoordinator(threading.Thread):
         self.worker_processes = []
         self.log.info("Restore coordinator stopped")
 
+    def _handle_broken_backup(self, stream_id: str):
+        broken_info = self._load_file_data("broken.json", stream_id=stream_id, missing_ok=True)
+        if broken_info and broken_info.get("broken_at"):
+            self.log.error("Cannot use backup=%s for restoration marked as broken, will try to switch backup", stream_id)
+            self.update_state(
+                phase=self.Phase.broken_basebackup,
+            )
+            return True
+        return False
+
     def get_backup_info(self) -> None:
         if not self.state["completed_info"]:
             completed_info = self._load_file_data("completed.json")
@@ -483,6 +494,9 @@ class RestoreCoordinator(threading.Thread):
 
         basebackup_info = self._load_file_data("basebackup.json")
         if not basebackup_info:
+            return
+
+        if self._handle_broken_backup(stream_id=self.stream_id):
             return
 
         required_backups = []
@@ -506,6 +520,9 @@ class RestoreCoordinator(threading.Thread):
                 if not completed_info:
                     self.log.error("Required backup %r is not complete, cannot restore", stream_id)
                     self.state_manager.increment_counter(name="restore_errors")
+                    return
+
+                if self._handle_broken_backup(stream_id=stream_id):
                     return
 
                 required_backups.append((stream_id, info))

--- a/test/local/test_controller.py
+++ b/test/local/test_controller.py
@@ -60,6 +60,80 @@ def test_backup_and_restore_fail_on_disk_full(
     )
 
 
+def test_restore_switches_to_previous_backup_when_latest_is_broken(
+    master_controller: tuple[Controller, MySQLConfig],
+    empty_controller: tuple[Controller, MySQLConfig],
+    caplog: LogCaptureFixture,
+) -> None:
+    """Test that restoration switches to the previous backup when the requested one is broken.
+
+    Builds a full backup followed by two incremental backups. The latest (incremental) backup is
+    marked broken only after the restoring controller has already fetched the backup list, so the
+    explicit restore request below still goes through; the restore coordinator must then discover
+    on its own, while restoring, that the requested backup is broken and fall back to the previous,
+    healthy incremental backup instead.
+    """
+    master, mysql_master = master_controller
+    target, mysql_target = empty_controller
+    mysql_target.connect_options["password"] = mysql_master.connect_options["password"]
+
+    flow_tester = ControllerFlowTester(master)
+    master.switch_to_active_mode()
+    master.start()
+    flow_tester.wait_for_streaming_binlogs()
+
+    populate_table(mysql_master, "test")
+    full_backup = do_backup_round(master, flow_tester, incremental=False)
+    assert not full_backup.state["basebackup_info"]["incremental"]
+
+    populate_table(mysql_master, "test")
+    previous_backup = do_backup_round(master, flow_tester, incremental=True)
+    assert previous_backup.state["basebackup_info"]["incremental"]
+
+    populate_table(mysql_master, "test")
+    broken_backup = do_backup_round(master, flow_tester, incremental=True)
+    assert broken_backup.state["basebackup_info"]["incremental"]
+
+    target_flow_tester = ControllerFlowTester(target)
+    target.start()
+    try:
+        target_flow_tester.wait_for_fetched_backup(timeout=2)
+
+        # Mark the latest backup as broken only now: the target's cached backup list (fetched
+        # above) still considers it healthy, so the restore request below is accepted. The restore
+        # coordinator itself must notice that the backup is broken once it starts restoring it.
+        master.mark_stream_as_broken(stream_id=broken_backup.stream_id, broken=True)
+
+        target.restore_backup(site=broken_backup.site, stream_id=broken_backup.stream_id)
+
+        # Two basebackups worth of restoring (the broken one is detected before anything is
+        # downloaded, then the previous one is restored in full) can take longer than the default.
+        target_flow_tester.wait_for_restore_phase(RestoreCoordinator.Phase.completed, timeout=60)
+    finally:
+        target.stop()
+
+    assert any(
+        f"Cannot use backup={broken_backup.stream_id}" in record.message and "marked as broken" in record.message
+        for record in caplog.records
+    )
+
+    # The restore coordinator must have switched to the previous, non-broken backup.
+    assert target.state["restore_options"]["stream_id"] == previous_backup.stream_id
+
+    orig_size = get_table_size(mysql_master, "test")
+    restored_size = get_table_size(mysql_target, "test")
+    assert orig_size == restored_size
+
+
+def do_backup_round(controller: Controller, flow_tester: ControllerFlowTester, *, incremental: bool) -> BackupStream:
+    """Request one more backup (full or incremental) on an already started, actively backing up controller."""
+    controller.mark_backup_requested(backup_reason=BackupStream.BackupReason.requested, incremental_requested=incremental)
+    flow_tester.wait_for_multiple_streams()
+    flow_tester.wait_for_streaming_binlogs()
+    flow_tester.wait_for_single_stream()
+    return controller.backup_streams[0]
+
+
 def do_backup(controller: Controller) -> list[BackupStream]:
     """Trigger a backup and wait for it to finish."""
     flow_tester = ControllerFlowTester(controller)


### PR DESCRIPTION
Broken backups were not skipped during restoration. It now checks if the backup is marked as broken and tries to switch to the previous working one.
